### PR TITLE
Fix compiler warnings from GetDoc report

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ use efficient_pca::eigensnp::{
 
 // Conditional import for EigenSNP diagnostics handling
 #[cfg(feature = "eigensnp-diagnostics")]
-use efficient_pca::diagnostics::FullPcaRunDetailedDiagnostics;
+// use efficient_pca::diagnostics::FullPcaRunDetailedDiagnostics; // Removed due to unused_imports warning
 #[cfg(feature = "eigensnp-diagnostics")]
 use serde_json;
 
@@ -187,7 +187,7 @@ fn run_vcf_workflow(cli_args: &CliArgs) -> Result<(), Error> {
     }
 
     info!("Aggregating variant data from {} processed VCF file segments...", all_good_chromosome_data.len());
-    let (variant_ids, chromosomes, positions, numerical_genotypes_variant_major) = aggregate_chromosome_data(all_good_chromosome_data);
+    let (variant_ids, numerical_genotypes_variant_major) = aggregate_chromosome_data(all_good_chromosome_data);
     let num_total_variants = variant_ids.len();
     info!("Aggregated {} variants in total across all VCFs.", num_total_variants);
     if num_total_variants == 0 { return Err(anyhow!("No variants available for PCA after aggregation.")); }

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -298,24 +298,24 @@ pub mod matrix_ops {
 
     pub fn aggregate_chromosome_data(
         per_chromosome_data: Vec<Vec<VariantGenotypeData>>,
-    ) -> (Vec<String>, Vec<String>, Vec<u64>, Vec<Vec<u8>>) {
+    ) -> (Vec<String>, Vec<Vec<u8>>) { // Changed return type
         let mut all_variant_ids = Vec::new();
-        let mut all_chromosomes = Vec::new();
-        let mut all_positions = Vec::new();
+        // Removed: let mut all_chromosomes = Vec::new();
+        // Removed: let mut all_positions = Vec::new();
         let mut all_numerical_genotypes_variant_major = Vec::new();
 
         for chrom_data_vec in per_chromosome_data {
             for variant_data in chrom_data_vec {
                 all_variant_ids.push(variant_data.id);
-                all_chromosomes.push(variant_data.chromosome);
-                all_positions.push(variant_data.position);
+                // Removed: all_chromosomes.push(variant_data.chromosome);
+                // Removed: all_positions.push(variant_data.position);
                 all_numerical_genotypes_variant_major.push(variant_data.numerical_genotypes);
             }
         }
         (
             all_variant_ids,
-            all_chromosomes,
-            all_positions,
+            // Removed: all_chromosomes,
+            // Removed: all_positions,
             all_numerical_genotypes_variant_major,
         )
     }


### PR DESCRIPTION
This commit addresses several compiler warnings identified in the GetDoc report:

- non_camel_case_types:
    - Renamed type parameter E_Original to EOriginal in WrapErr trait and impl in src/prepare.rs.

- unused_variables:
    - Used min_snp_call_rate_thresh in SNP QC logic in src/prepare.rs.
    - Removed unused chromosomes and positions variables from the return of aggregate_chromosome_data in src/vcf.rs and its call site in src/main.rs.

- dead_code (fields):
    - Removed unused fields allele1 and allele2 from IntermediateSnpDetails in src/prepare.rs.
    - Kept IoTaskMetrics fields (actor_id, duration_micros, queue_len_at_pickup) as they are intended for metrics collection, despite current dead_code warnings for them.

- dead_code (constants):
    - Removed unused constants MAX_ACCEPTABLE_AVG_TASK_TIME_US, MIN_THROUGHPUT_IMPROVEMENT_RATIO_FOR_SCALING_UP, and MAX_THROUGHPUT_DROP_RATIO_FOR_SCALING_DOWN_REVERSAL from io_service_infrastructure module in src/prepare.rs.

- unused_imports:
    - Removed unused import efficient_pca::diagnostics::FullPcaRunDetailedDiagnostics from src/main.rs.