### PR TITLE
Fix various compilation errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
     time::Instant,
+    time::Duration,
 };
 use libc; // Added for getrlimit
 
@@ -190,7 +191,7 @@ fn run_vcf_workflow(cli_args: &CliArgs) -> Result<(), Error> {
 
     info!("Aggregating variant data from {} processed VCF file segments...", all_good_chromosome_data.len());
     let vcf_aggregation_start_time = Instant::now();
-    let (variant_ids, numerical_genotypes_variant_major) = aggregate_chromosome_data(all_good_chromosome_data);
+    let (variant_ids, _all_chromosomes, _all_positions, numerical_genotypes_variant_major) = aggregate_chromosome_data(all_good_chromosome_data);
     let num_total_variants = variant_ids.len();
     info!("Aggregated {} variants in total across all VCFs.", num_total_variants);
     if num_total_variants == 0 { return Err(anyhow!("No variants available for PCA after aggregation.")); }


### PR DESCRIPTION
This commit addresses several compilation errors:

- E0412 (not found in this scope): Added `use std::time::Duration;` to `src/main.rs`.
- E0308 (mismatched types): Adjusted the destructuring of the result from `aggregate_chromosome_data` in `src/main.rs` to expect a 4-element tuple, as indicated by the compiler error. The two new (middle) elements are currently marked as unused.
- E0382 (borrow of moved value): Cloned `original_m_indices` in `src/prepare.rs` before it's moved into `IoResponse::RawSnpChunkForQc` to allow its subsequent use.
- Unused import: Removed unused `Array1` import from `src/prepare.rs`.