### PR TITLE
I've fixed various compilation errors related to SIMD, attributes, an…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(portable_simd)]
 // main.rs
 
 // --- Local Module Declarations ---
@@ -24,7 +25,7 @@ use std::{
 };
 use libc; // Added for getrlimit
 
-#![cfg_attr(
+#[cfg_attr(
     not(any(
         feature = "openblas-openblas",
         feature = "openblas-faer",


### PR DESCRIPTION
…d imports in your code.

Here's what I addressed:
- Corrected an inner attribute error in src/main.rs.
- Enabled the portable_simd feature in src/main.rs.
- Fixed SIMD trait imports in src/prepare.rs.
- Resolved a MaybeUninit assignment error in src/prepare.rs.
- Removed incorrect .expect() calls on non-Option types in src/prepare.rs.
- Replaced write_to_slice_unaligned with write_to_slice in src/prepare.rs.
- Removed unused labels in src/prepare.rs.

Please note: The project might still not build in an environment with rustc 1.75.0. This is due to compiler version incompatibilities with external dependencies (e.g., private-gemm-x86 via efficient_pca). These changes address the specified Rust language and SIMD usage errors within your project's own code.