### PR TITLE
The GitHub Actions workflow was previously using the stable Rust tool…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
         
       - name: Install Rust toolchain
         id: install_rust
-        uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt, clippy
           


### PR DESCRIPTION
…chain.

This change updates the workflow to use the latest nightly version of Rust.