### PR TITLE
Fix various compilation errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,15 +25,13 @@ use std::{
 };
 use libc; // Added for getrlimit
 
-#[cfg_attr(
-    not(any(
-        feature = "openblas-openblas",
-        feature = "openblas-faer",
-        feature = "mkl-mkl",
-        feature = "mkl-faer"
-    )),
-    compile_error!("ERROR: no BLAS/LAPACK backend was selected for genomic_pca. You must build with exactly one of the features enabled.")
-)]
+#[cfg(not(any(
+    feature = "openblas-openblas",
+    feature = "openblas-faer",
+    feature = "mkl-mkl",
+    feature = "mkl-faer"
+)))]
+compile_error!("ERROR: no BLAS/LAPACK backend was selected for genomic_pca. You must build with exactly one of the features enabled.");
 
 // --- Helper Function to Query Soft Resource Limits ---
 fn get_rlimit_soft(resource: libc::c_uint) -> Result<usize, std::io::Error> {


### PR DESCRIPTION
This commit addresses several compilation errors:

1.  Corrected `compile_error!` macro usage in `src/main.rs`. The macro was incorrectly used as a `cfg_attr` attribute. Changed to `#[cfg(...)] compile_error!(...);` for direct conditional compilation failure.

2.  Imported `SimdUint` trait in `src/prepare.rs`. Added `use std::simd::num::SimdUint;` to resolve `E0599` errors where the `reduce_sum` method was not found for `Simd<u8, 16>`.

3.  Fixed `Simd::write_to_slice` method calls in `src/prepare.rs`. The method expects `&mut [T; LANES]`, but was being called with `&mut [T]`. Changed to obtain a correct array reference using `try_into().expect(...)` before calling `write_to_slice`.

4.  Resolved type mismatch `E0308` in `src/prepare.rs`. Changed direct assignment to `MaybeUninit<f32>` (e.g., `slice[idx] = val`) to use the `.write()` method (e.g., `slice[idx].write(val)`), which is the correct way to initialize `MaybeUninit` data.

These changes should allow the project to compile successfully.