### PR TITLE
Fix SIMD operations in prepare.rs

### DIFF
--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -1928,9 +1928,14 @@ impl PcaReadyGenotypeAccessor for MicroarrayGenotypeAccessor {
                                         // i_req_sample += LANES_I8_F32_8;
                                         // continue 'simd_loop_zero_std_dev;
                                     }
-                                    let sub_slice = &mut std_mut_slice[i_req_sample..i_req_sample + LANES_I8_F32_8];
-                                    let array_ref: &mut [f32; LANES_I8_F32_8] = sub_slice.try_into().expect("Slice segment has incorrect length for SIMD write");
-                                    simd_zeros.write_to_slice(array_ref);
+                                    let target_slice: &mut [std::mem::MaybeUninit<f32>] = &mut std_mut_slice[i_req_sample..i_req_sample + LANES_I8_F32_8];
+                                    unsafe {
+                                        let initialized_slice = std::slice::from_raw_parts_mut(
+                                            target_slice.as_mut_ptr() as *mut f32,
+                                            LANES_I8_F32_8
+                                        );
+                                        simd_zeros.write_to_slice_unaligned(initialized_slice);
+                                    }
                                     i_req_sample += LANES_I8_F32_8;
                                 }
                             }
@@ -1976,9 +1981,14 @@ impl PcaReadyGenotypeAccessor for MicroarrayGenotypeAccessor {
                                     }
                                     let raw_f32_chunk: Simd<f32, LANES_I8_F32_8> = raw_i8_chunk.cast();
                                     let standardized_chunk = (raw_f32_chunk - simd_mean) / simd_std_dev;
-                                    let sub_slice = &mut std_mut_slice[i_req_sample..i_req_sample + LANES_I8_F32_8];
-                                    let array_ref: &mut [f32; LANES_I8_F32_8] = sub_slice.try_into().expect("Slice segment has incorrect length for SIMD write");
-                                    standardized_chunk.write_to_slice(array_ref);
+                                    let target_slice: &mut [std::mem::MaybeUninit<f32>] = &mut std_mut_slice[i_req_sample..i_req_sample + LANES_I8_F32_8];
+                                    unsafe {
+                                        let initialized_slice = std::slice::from_raw_parts_mut(
+                                            target_slice.as_mut_ptr() as *mut f32,
+                                            LANES_I8_F32_8
+                                        );
+                                        standardized_chunk.write_to_slice_unaligned(initialized_slice);
+                                    }
                                     i_req_sample += LANES_I8_F32_8;
                                 }
                             }


### PR DESCRIPTION
This commit addresses compilation errors E0599 and E0277 in `src/prepare.rs` related to SIMD operations.

The `Simd::write_to_slice` method was being called on a type that did not support it, and there was an incorrect `try_into()` conversion from a `&mut [MaybeUninit<f32>]` to `&mut [f32; N]`.

The fix involves:
- Removing the incorrect `try_into()` conversion.
- Using `Simd::write_to_slice_unaligned` to write SIMD vector data.
- Correctly handling `MaybeUninit<f32>` slices by unsafely casting their raw pointers to `*mut f32` and creating new slices for the `write_to_slice_unaligned` method. This ensures that the uninitialized memory is properly written to by the SIMD operations.

These changes were applied in the `get_standardized_snp_sample_block` method for both the zero and non-zero standard deviation cases.