### PR TITLE
feat: Add --save-local-pcs flag for EigenSNP workflow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,15 @@
 // main.rs
 
 // --- Local Module Declarations ---
-mod vcf;
 mod prepare;
+mod vcf;
 
 // --- External Crate Imports ---
 use anyhow::{anyhow, Error, Result};
 use clap::Parser;
 use env_logger;
 use indicatif::{ProgressBar, ProgressStyle};
+use libc;
 use log::{debug, error, info, warn};
 use ndarray::Array2; // Aliased 's'
 use noodles_vcf::{self as noodles_vcf_crate}; // Aliased noodles_vcf
@@ -20,10 +21,9 @@ use std::{
     io::{BufWriter, Write},
     path::PathBuf,
     sync::Arc,
-    time::Instant,
     time::Duration,
+    time::Instant,
 };
-use libc; // Added for getrlimit
 
 #[cfg(not(any(
     feature = "openblas-openblas",
@@ -53,21 +53,21 @@ fn get_rlimit_soft(resource: libc::c_uint) -> Result<usize, std::io::Error> {
 // --- Imports for Local Project Crates/Modules (Workflows) ---
 use crate::cli::CliArgs;
 // VCF Workflow specific
-use crate::vcf::vcf_processing::SamplesHeaderInfo;
-use crate::vcf::matrix_ops::{aggregate_chromosome_data, build_matrix};
 use crate::pca_runner::run_genomic_pca;
+use crate::vcf::matrix_ops::{aggregate_chromosome_data, build_matrix};
+use crate::vcf::vcf_processing::SamplesHeaderInfo;
 // EigenSNP-Rust Data Preparation (local, from src/prepare.rs)
 use crate::prepare::{MicroarrayDataPreparer, MicroarrayDataPreparerConfig};
-
 
 // --- Imports for External `efficient_pca` Crate ---
 use efficient_pca::PCA as EfficientPcaModel; // For the VCF workflow
 
 // For EigenSNP-Rust Core Algorithm & Interface Types from external crate
 use efficient_pca::eigensnp::{
-    EigenSNPCoreAlgorithm, EigenSNPCoreAlgorithmConfig,   // Trait implemented by MicroarrayGenotypeAccessor in src/prepare.rs
-    // PcaSnpId, QcSampleId,    // These are used by types above and in src/prepare.rs
-    // ThreadSafeStdError,      // Used in PcaReadyGenotypeAccessor definition in src/prepare.rs
+    EigenSNPCoreAlgorithm,
+    EigenSNPCoreAlgorithmConfig, // Trait implemented by MicroarrayGenotypeAccessor in src/prepare.rs
+                                 // PcaSnpId, QcSampleId,    // These are used by types above and in src/prepare.rs
+                                 // ThreadSafeStdError,      // Used in PcaReadyGenotypeAccessor definition in src/prepare.rs
 };
 
 // Conditional import for EigenSNP diagnostics handling
@@ -113,17 +113,25 @@ fn main() -> Result<(), Error> {
         info!("Default VCF processing workflow selected.");
         // Validate required arguments for VCF workflow
         if cli_args.vcf_dir.is_none() {
-            return Err(anyhow!("--vcf-dir is required for the default VCF workflow."));
+            return Err(anyhow!(
+                "--vcf-dir is required for the default VCF workflow."
+            ));
         }
         if cli_args.components.is_none() {
-             return Err(anyhow!("-k/--components is required for the default VCF workflow."));
+            return Err(anyhow!(
+                "-k/--components is required for the default VCF workflow."
+            ));
         }
         run_vcf_workflow(&cli_args)?;
     }
 
     info!(
         "genomic_pca (mode: {}) finished successfully in {:.2?}.",
-        if cli_args.eigensnp { "EigenSNP-Rust" } else { "VCF" },
+        if cli_args.eigensnp {
+            "EigenSNP-Rust"
+        } else {
+            "VCF"
+        },
         total_time_start.elapsed()
     );
     Ok(())
@@ -132,7 +140,10 @@ fn main() -> Result<(), Error> {
 // --- VCF Workflow Function ---
 fn run_vcf_workflow(cli_args: &CliArgs) -> Result<(), Error> {
     // Unwrap validated VCF workflow specific arguments
-    let vcf_dir = cli_args.vcf_dir.as_ref().expect("--vcf-dir is required for VCF workflow and should be validated by now");
+    let vcf_dir = cli_args
+        .vcf_dir
+        .as_ref()
+        .expect("--vcf-dir is required for VCF workflow and should be validated by now");
     // Note: cli_args.components is unwrapped inside pca_runner::run_genomic_pca
 
     info!("Discovering VCF files in directory: {}", vcf_dir.display());
@@ -141,24 +152,49 @@ fn run_vcf_workflow(cli_args: &CliArgs) -> Result<(), Error> {
         .map(|entry| entry.path())
         .filter(|path| {
             path.is_file()
-                && (path.extension().map_or(false, |ext| ext == "vcf" || ext == "gz"))
-                && (path.file_name().map_or(false, |name| name.to_string_lossy().contains(".vcf")))
+                && (path
+                    .extension()
+                    .map_or(false, |ext| ext == "vcf" || ext == "gz"))
+                && (path
+                    .file_name()
+                    .map_or(false, |name| name.to_string_lossy().contains(".vcf")))
         })
         .collect();
 
     if vcf_files.is_empty() {
-        return Err(anyhow!("No VCF files (ending in .vcf or .vcf.gz) found in directory: {}", vcf_dir.display()));
+        return Err(anyhow!(
+            "No VCF files (ending in .vcf or .vcf.gz) found in directory: {}",
+            vcf_dir.display()
+        ));
     }
     vcf_files.sort(); // consistent processing order
-    info!("Found {} VCF file(s). Processing order (first 5 shown): {:?}", vcf_files.len(), vcf_files.iter().take(5).collect::<Vec<_>>());
+    info!(
+        "Found {} VCF file(s). Processing order (first 5 shown): {:?}",
+        vcf_files.len(),
+        vcf_files.iter().take(5).collect::<Vec<_>>()
+    );
 
     let first_vcf_path = &vcf_files[0];
-    info!("Reading header from first VCF file: {}", first_vcf_path.display());
-    let mut first_reader = noodles_vcf_crate::io::reader::Builder::default().build_from_path(first_vcf_path)?;
+    info!(
+        "Reading header from first VCF file: {}",
+        first_vcf_path.display()
+    );
+    let mut first_reader =
+        noodles_vcf_crate::io::reader::Builder::default().build_from_path(first_vcf_path)?;
     let header_template = Arc::new(first_reader.read_header()?);
-    let samples_info = Arc::new(SamplesHeaderInfo::from_header(&header_template, first_vcf_path)?);
-    info!("Established sample set from {}: {} samples. All other VCFs must match this set and order.", first_vcf_path.display(), samples_info.sample_count);
-    debug!("Sample names (first 5): {:?}", samples_info.sample_names.iter().take(5).collect::<Vec<_>>());
+    let samples_info = Arc::new(SamplesHeaderInfo::from_header(
+        &header_template,
+        first_vcf_path,
+    )?);
+    info!(
+        "Established sample set from {}: {} samples. All other VCFs must match this set and order.",
+        first_vcf_path.display(),
+        samples_info.sample_count
+    );
+    debug!(
+        "Sample names (first 5): {:?}",
+        samples_info.sample_names.iter().take(5).collect::<Vec<_>>()
+    );
 
     info!("Processing {} VCF file(s) in parallel...", vcf_files.len());
     let vcf_processing_start_time = Instant::now();
@@ -168,80 +204,155 @@ fn run_vcf_workflow(cli_args: &CliArgs) -> Result<(), Error> {
         .progress_chars("=> ");
     let pb_vcf = ProgressBar::new(vcf_files.len() as u64).with_style(pb_vcf_style.clone()); // Clone for thread safety if needed by ProgressBar internals
 
-    let per_chromosome_data_results: Vec<Result<Option<Vec<vcf::vcf_processing::VariantGenotypeData>>>> = vcf_files
+    let per_chromosome_data_results: Vec<
+        Result<Option<Vec<vcf::vcf_processing::VariantGenotypeData>>>,
+    > = vcf_files
         .par_iter()
         .map(|vcf_path| {
             // cli_args is passed to process_single_vcf if it needs it for MAF etc.
-            let result = crate::vcf::vcf_processing::process_single_vcf(vcf_path, samples_info.clone(), cli_args, first_vcf_path);
+            let result = crate::vcf::vcf_processing::process_single_vcf(
+                vcf_path,
+                samples_info.clone(),
+                cli_args,
+                first_vcf_path,
+            );
             pb_vcf.inc(1);
             result
         })
         .collect();
     pb_vcf.finish_with_message("VCF processing complete.");
 
-    let mut all_good_chromosome_data: Vec<Vec<vcf::vcf_processing::VariantGenotypeData>> = Vec::new();
+    let mut all_good_chromosome_data: Vec<Vec<vcf::vcf_processing::VariantGenotypeData>> =
+        Vec::new();
     let mut processing_errors: Vec<Error> = Vec::new();
     for (i, result_chunk) in per_chromosome_data_results.into_iter().enumerate() {
         match result_chunk {
             Ok(Some(data)) if !data.is_empty() => all_good_chromosome_data.push(data),
-            Ok(Some(_)) | Ok(None) => debug!("No variants passed filters for VCF: {}", vcf_files[i].display()),
-            Err(e) => processing_errors.push(anyhow!("Error processing VCF file {}: {}", vcf_files[i].display(), e)),
+            Ok(Some(_)) | Ok(None) => debug!(
+                "No variants passed filters for VCF: {}",
+                vcf_files[i].display()
+            ),
+            Err(e) => processing_errors.push(anyhow!(
+                "Error processing VCF file {}: {}",
+                vcf_files[i].display(),
+                e
+            )),
         }
     }
-    info!("Parallel VCF file processing completed in {:.2?}.", vcf_processing_start_time.elapsed());
+    info!(
+        "Parallel VCF file processing completed in {:.2?}.",
+        vcf_processing_start_time.elapsed()
+    );
 
     if !processing_errors.is_empty() {
-        for err in processing_errors { error!("{}", err); }
-        return Err(anyhow!("Failed to process one or more VCF files. See errors above."));
+        for err in processing_errors {
+            error!("{}", err);
+        }
+        return Err(anyhow!(
+            "Failed to process one or more VCF files. See errors above."
+        ));
     }
     if all_good_chromosome_data.is_empty() {
-        return Err(anyhow!("No variants passed filters across all VCF files. Cannot proceed with PCA."));
+        return Err(anyhow!(
+            "No variants passed filters across all VCF files. Cannot proceed with PCA."
+        ));
     }
 
-    info!("Aggregating variant data from {} processed VCF file segments...", all_good_chromosome_data.len());
+    info!(
+        "Aggregating variant data from {} processed VCF file segments...",
+        all_good_chromosome_data.len()
+    );
     let vcf_aggregation_start_time = Instant::now();
-    let (variant_ids, numerical_genotypes_variant_major) = aggregate_chromosome_data(all_good_chromosome_data);
+    let (variant_ids, numerical_genotypes_variant_major) =
+        aggregate_chromosome_data(all_good_chromosome_data);
     let num_total_variants = variant_ids.len();
 
-    info!("Aggregated {} variants in total across all VCFs.", num_total_variants);
-    if num_total_variants == 0 { return Err(anyhow!("No variants available for PCA after aggregation.")); }
+    info!(
+        "Aggregated {} variants in total across all VCFs.",
+        num_total_variants
+    );
+    if num_total_variants == 0 {
+        return Err(anyhow!("No variants available for PCA after aggregation."));
+    }
 
-    info!("Building genotype matrix ({} samples x {} variants) for VCF workflow...", samples_info.sample_count, num_total_variants);
-    let genotype_matrix = build_matrix(numerical_genotypes_variant_major, samples_info.sample_count)?;
-    info!("VCF data aggregation and matrix construction completed in {:.2?}.", vcf_aggregation_start_time.elapsed());
-
+    info!(
+        "Building genotype matrix ({} samples x {} variants) for VCF workflow...",
+        samples_info.sample_count, num_total_variants
+    );
+    let genotype_matrix =
+        build_matrix(numerical_genotypes_variant_major, samples_info.sample_count)?;
+    info!(
+        "VCF data aggregation and matrix construction completed in {:.2?}.",
+        vcf_aggregation_start_time.elapsed()
+    );
 
     info!("Running PCA using efficient-pca library for VCF workflow...");
     let vcf_pca_algo_start_time = Instant::now();
     let (_pca_model, transformed_pcs, pc_variances) = run_genomic_pca(genotype_matrix, cli_args)?;
-    info!("VCF PCA computation complete. Resulted in {} principal components.", transformed_pcs.ncols());
+    info!(
+        "VCF PCA computation complete. Resulted in {} principal components.",
+        transformed_pcs.ncols()
+    );
 
     let output_prefix_path = PathBuf::from(&cli_args.output_prefix);
     if let Some(parent) = output_prefix_path.parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
-            std::fs::create_dir_all(parent).map_err(|e| anyhow!("Failed to create output directory {}: {}", parent.display(), e))?;
+            std::fs::create_dir_all(parent).map_err(|e| {
+                anyhow!(
+                    "Failed to create output directory {}: {}",
+                    parent.display(),
+                    e
+                )
+            })?;
             info!("Created output directory: {}", parent.display());
         }
     }
-    info!("VCF PCA computation (efficient-pca rfit) completed in {:.2?}.", vcf_pca_algo_start_time.elapsed());
+    info!(
+        "VCF PCA computation (efficient-pca rfit) completed in {:.2?}.",
+        vcf_pca_algo_start_time.elapsed()
+    );
 
-    info!("Writing VCF PCA results to files with prefix '{}'...", cli_args.output_prefix);
+    info!(
+        "Writing VCF PCA results to files with prefix '{}'...",
+        cli_args.output_prefix
+    );
     let vcf_output_writing_start_time = Instant::now();
 
-    output_writer::write_principal_components_f64(&cli_args.output_prefix, &samples_info.sample_names, &transformed_pcs)?;
+    output_writer::write_principal_components_f64(
+        &cli_args.output_prefix,
+        &samples_info.sample_names,
+        &transformed_pcs,
+    )?;
     output_writer::write_eigenvalues(&cli_args.output_prefix, &pc_variances)?;
     warn!("Loadings output for VCF-based PCA is currently skipped (not directly available from efficient-pca rfit).");
-    info!("VCF PCA results written in {:.2?}.", vcf_output_writing_start_time.elapsed());
-
+    info!(
+        "VCF PCA results written in {:.2?}.",
+        vcf_output_writing_start_time.elapsed()
+    );
 
     info!("--- VCF Workflow Stage Timings ---");
     // Note: This aggregates some of the logged times manually for a summary.
     // A more structured timing vector like in EigenSNP workflow could be implemented if desired.
-    info!("{:<40}: {:.2?}", "VCF File Processing (Parallel)", vcf_processing_start_time.elapsed());
-    info!("{:<40}: {:.2?}", "VCF Aggregation & Matrix Build", vcf_aggregation_start_time.elapsed());
-    info!("{:<40}: {:.2?}", "VCF PCA Algorithm (efficient-pca)", vcf_pca_algo_start_time.elapsed());
-    info!("{:<40}: {:.2?}", "VCF Output Writing", vcf_output_writing_start_time.elapsed());
-
+    info!(
+        "{:<40}: {:.2?}",
+        "VCF File Processing (Parallel)",
+        vcf_processing_start_time.elapsed()
+    );
+    info!(
+        "{:<40}: {:.2?}",
+        "VCF Aggregation & Matrix Build",
+        vcf_aggregation_start_time.elapsed()
+    );
+    info!(
+        "{:<40}: {:.2?}",
+        "VCF PCA Algorithm (efficient-pca)",
+        vcf_pca_algo_start_time.elapsed()
+    );
+    info!(
+        "{:<40}: {:.2?}",
+        "VCF Output Writing",
+        vcf_output_writing_start_time.elapsed()
+    );
 
     Ok(())
 }
@@ -279,8 +390,8 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
     const MIN_EFFECTIVE_IO_ACTORS: usize = 2;
     const MAX_HEURISTIC_IO_ACTORS: usize = 16; // Heuristic cap
     let absolute_max_io_actors_for_ioservice = (actual_num_compute_threads / 2) // Allow compute threads to primarily focus on Rayon tasks
-                                               .max(MIN_EFFECTIVE_IO_ACTORS)
-                                               .min(MAX_HEURISTIC_IO_ACTORS);
+        .max(MIN_EFFECTIVE_IO_ACTORS)
+        .min(MAX_HEURISTIC_IO_ACTORS);
 
     // Log Derived Boundaries
     info!(
@@ -292,17 +403,26 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
     let stage_start_time = Instant::now();
 
     // 1. Create Configurations from cli_args
-    let bed_file_path_str = cli_args.bed_file.as_ref()
+    let bed_file_path_str = cli_args
+        .bed_file
+        .as_ref()
         .ok_or_else(|| anyhow!("--bed-file is required when --eigensnp is used"))?
-        .to_string_lossy().into_owned();
-    let ld_block_file_path_str = cli_args.ld_block_file.as_ref()
+        .to_string_lossy()
+        .into_owned();
+    let ld_block_file_path_str = cli_args
+        .ld_block_file
+        .as_ref()
         .ok_or_else(|| anyhow!("--ld-block-file is required when --eigensnp is used"))?
-        .to_string_lossy().into_owned();
+        .to_string_lossy()
+        .into_owned();
 
     let prep_config = MicroarrayDataPreparerConfig {
         bed_file_path: bed_file_path_str,
         ld_block_file_path: ld_block_file_path_str,
-        sample_ids_to_keep_file_path: cli_args.eigensnp_sample_keep_file.as_ref().map(|p| p.to_string_lossy().into_owned()),
+        sample_ids_to_keep_file_path: cli_args
+            .eigensnp_sample_keep_file
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned()),
         min_snp_call_rate_threshold: cli_args.eigensnp_min_call_rate.unwrap_or(0.98),
         min_snp_maf_threshold: cli_args.eigensnp_min_maf.unwrap_or(0.01),
         max_snp_hwe_p_value_threshold: cli_args.eigensnp_max_hwe_p.unwrap_or(1e-4),
@@ -313,8 +433,12 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
         target_num_global_pcs: cli_args.eigensnp_k_global.unwrap_or(10),
         components_per_ld_block: cli_args.eigensnp_components_per_block.unwrap_or(10),
         subset_factor_for_local_basis_learning: cli_args.eigensnp_subset_factor.unwrap_or(0.1),
-        min_subset_size_for_local_basis_learning: cli_args.eigensnp_min_subset_size.unwrap_or(20_000),
-        max_subset_size_for_local_basis_learning: cli_args.eigensnp_max_subset_size.unwrap_or(60_000),
+        min_subset_size_for_local_basis_learning: cli_args
+            .eigensnp_min_subset_size
+            .unwrap_or(20_000),
+        max_subset_size_for_local_basis_learning: cli_args
+            .eigensnp_max_subset_size
+            .unwrap_or(60_000),
         global_pca_sketch_oversampling: cli_args.eigensnp_global_oversampling.unwrap_or(10),
         global_pca_num_power_iterations: cli_args.eigensnp_global_power_iter.unwrap_or(2),
         local_rsvd_sketch_oversampling: cli_args.eigensnp_local_oversampling.unwrap_or(3),
@@ -322,6 +446,12 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
         random_seed: cli_args.eigensnp_seed.unwrap_or(2025),
         snp_processing_strip_size: cli_args.eigensnp_snp_strip_size.unwrap_or(2000),
         refine_pass_count: cli_args.eigensnp_refine_passes.unwrap_or(1),
+
+        local_pcs_output_dir: cli_args
+            .save_local_pcs
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned()),
+
         collect_diagnostics: cli_args.eigensnp_collect_diagnostics,
         #[cfg(feature = "eigensnp-diagnostics")]
         diagnostic_block_list_id_to_trace: None,
@@ -330,24 +460,42 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
     // 2. Prepare Data using MicroarrayDataPreparer (from crate::prepare)
     info!("Initializing MicroarrayDataPreparer (includes initial BIM/FAM metadata loading)...");
     let preparer_init_start = Instant::now();
-    let preparer = MicroarrayDataPreparer::try_new(
-        prep_config,
-        absolute_max_io_actors_for_ioservice,
-    )
-        .map_err(|e| anyhow!("Failed to initialize MicroarrayDataPreparer from src/prepare.rs: {}", e))?;
-    stage_timings.push(("Preparer Initialization".to_string(), preparer_init_start.elapsed()));
-    info!("MicroarrayDataPreparer initialized in {:.2?}.", preparer_init_start.elapsed());
+    let preparer =
+        MicroarrayDataPreparer::try_new(prep_config, absolute_max_io_actors_for_ioservice)
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to initialize MicroarrayDataPreparer from src/prepare.rs: {}",
+                    e
+                )
+            })?;
+    stage_timings.push((
+        "Preparer Initialization".to_string(),
+        preparer_init_start.elapsed(),
+    ));
+    info!(
+        "MicroarrayDataPreparer initialized in {:.2?}.",
+        preparer_init_start.elapsed()
+    );
 
     info!("Preparing data for EigenSNP-Rust (includes QC, standardization, LD mapping)...");
     // prepare_data_for_eigen_snp returns types from efficient_pca::eigensnp if src/prepare.rs was modified correctly
     let main_data_prep_start = Instant::now();
     let (genotype_accessor, ld_block_specifications, num_qc_samples, num_pca_snps) =
-        preparer.prepare_data_for_eigen_snp()
-            .map_err(|e| anyhow!("Data preparation (src/prepare.rs) for EigenSNP-Rust failed: {}", e))?;
-    stage_timings.push(("Main Data Preparation (QC, LD Map)".to_string(), main_data_prep_start.elapsed()));
+        preparer.prepare_data_for_eigen_snp().map_err(|e| {
+            anyhow!(
+                "Data preparation (src/prepare.rs) for EigenSNP-Rust failed: {}",
+                e
+            )
+        })?;
+    stage_timings.push((
+        "Main Data Preparation (QC, LD Map)".to_string(),
+        main_data_prep_start.elapsed(),
+    ));
     info!(
         "EigenSNP-Rust Data prepared in {:.2?}: {} QC'd samples, {} PCA SNPs for analysis.",
-        main_data_prep_start.elapsed(), num_qc_samples, num_pca_snps
+        main_data_prep_start.elapsed(),
+        num_qc_samples,
+        num_pca_snps
     );
 
     if num_qc_samples == 0 || num_pca_snps == 0 {
@@ -363,26 +511,49 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
     // compute_pca expects &impl PcaReadyGenotypeAccessor and &[LdBlockSpecification]
     // where these types are from efficient_pca::eigensnp
     let eigensnp_algo_start = Instant::now();
-    let (pca_output, diagnostics_option) = algorithm.compute_pca(&genotype_accessor, &ld_block_specifications)
-        .map_err(|e| anyhow!("EigenSNP-Rust PCA computation (efficient_pca crate) failed: {}", e))?;
-    stage_timings.push(("EigenSNP Algorithm".to_string(), eigensnp_algo_start.elapsed()));
-    info!("EigenSNP-Rust PCA algorithm completed in {:.2?}.", eigensnp_algo_start.elapsed());
+    let (pca_output, diagnostics_option) = algorithm
+        .compute_pca(&genotype_accessor, &ld_block_specifications)
+        .map_err(|e| {
+            anyhow!(
+                "EigenSNP-Rust PCA computation (efficient_pca crate) failed: {}",
+                e
+            )
+        })?;
+    stage_timings.push((
+        "EigenSNP Algorithm".to_string(),
+        eigensnp_algo_start.elapsed(),
+    ));
+    info!(
+        "EigenSNP-Rust PCA algorithm completed in {:.2?}.",
+        eigensnp_algo_start.elapsed()
+    );
 
     // 4. Write Outputs
     let output_writing_start = Instant::now();
     let output_prefix_path = PathBuf::from(&cli_args.output_prefix);
-     if let Some(parent) = output_prefix_path.parent() {
+    if let Some(parent) = output_prefix_path.parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
-            std::fs::create_dir_all(parent).map_err(|e| anyhow!("Failed to create output directory {}: {}", parent.display(), e))?;
+            std::fs::create_dir_all(parent).map_err(|e| {
+                anyhow!(
+                    "Failed to create output directory {}: {}",
+                    parent.display(),
+                    e
+                )
+            })?;
             info!("Created output directory: {}", parent.display());
         }
     }
-    info!("Writing EigenSNP-Rust PCA results to files with prefix '{}'...", cli_args.output_prefix);
+    info!(
+        "Writing EigenSNP-Rust PCA results to files with prefix '{}'...",
+        cli_args.output_prefix
+    );
 
     // Retrieve QC'd sample names using the accessor for original_indices_of_qc_samples
     let ordered_qc_sample_names = get_eigensnp_ordered_qc_sample_names(
         &preparer,
-        genotype_accessor.original_indices_of_qc_samples().as_slice(), // 
+        genotype_accessor
+            .original_indices_of_qc_samples()
+            .as_slice(), //
     )?;
     output_writer::write_principal_components_f32(
         &cli_args.output_prefix,
@@ -407,7 +578,7 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
         &pca_snp_pos,
         &pca_output.final_snp_principal_component_loadings,
     )?;
-    
+
     // Conditional diagnostics output
     #[cfg(feature = "eigensnp-diagnostics")]
     if cli_args.eigensnp_collect_diagnostics {
@@ -420,27 +591,41 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
             match serde_json::to_string_pretty(&diag_data) {
                 Ok(json_string) => {
                     if let Err(e_write) = std::fs::write(&diag_filename, json_string) {
-                        warn!("Failed to write EigenSNP diagnostics to {}: {}", diag_filename, e_write);
+                        warn!(
+                            "Failed to write EigenSNP diagnostics to {}: {}",
+                            diag_filename, e_write
+                        );
                     }
                 }
-                Err(e_json) => warn!("Failed to serialize EigenSNP diagnostics to JSON: {}", e_json),
+                Err(e_json) => warn!(
+                    "Failed to serialize EigenSNP diagnostics to JSON: {}",
+                    e_json
+                ),
             }
         } else {
-             info!("EigenSNP-Rust diagnostics collection was enabled via CLI, but no diagnostic data structure was returned from PCA computation (this might happen if the 'eigensnp-diagnostics' feature is not active in the 'efficient_pca' library itself).");
+            info!("EigenSNP-Rust diagnostics collection was enabled via CLI, but no diagnostic data structure was returned from PCA computation (this might happen if the 'eigensnp-diagnostics' feature is not active in the 'efficient_pca' library itself).");
         }
     }
     #[cfg(not(feature = "eigensnp-diagnostics"))]
-    { let _ = diagnostics_option; /* Mark as used if diagnostics feature is off */ }
+    {
+        let _ = diagnostics_option; /* Mark as used if diagnostics feature is off */
+    }
 
     stage_timings.push(("Output Writing".to_string(), output_writing_start.elapsed()));
-    info!("EigenSNP-Rust results written in {:.2?}.", output_writing_start.elapsed());
+    info!(
+        "EigenSNP-Rust results written in {:.2?}.",
+        output_writing_start.elapsed()
+    );
 
     info!("--- EigenSNP-Rust Workflow Stage Timings ---");
     for (stage_name, duration) in &stage_timings {
         info!("{:<40}: {:.2?}", stage_name, duration);
     }
     let total_eigensnp_workflow_time = stage_start_time.elapsed();
-    info!("{:<40}: {:.2?}", "Total EigenSNP Workflow Time (main.rs)", total_eigensnp_workflow_time);
+    info!(
+        "{:<40}: {:.2?}",
+        "Total EigenSNP Workflow Time (main.rs)", total_eigensnp_workflow_time
+    );
     // Note: This total is from within run_eigensnp_rust_workflow.
     // The overall main function total_time_start includes CLI parsing and logger init.
 
@@ -449,7 +634,7 @@ fn run_eigensnp_rust_workflow(cli_args: &CliArgs) -> Result<(), Error> {
 
 // --- Helper for EigenSNP-Rust Ordered QC'd Sample Names ---
 fn get_eigensnp_ordered_qc_sample_names(
-    preparer: &MicroarrayDataPreparer,      // From crate::prepare
+    preparer: &MicroarrayDataPreparer,    // From crate::prepare
     qc_sample_original_indices: &[isize], // From MicroarrayGenotypeAccessor in crate::prepare
 ) -> Result<Vec<String>, Error> {
     let initial_fam_ids = preparer.initial_sample_ids_from_fam_arc();
@@ -471,8 +656,8 @@ fn get_eigensnp_ordered_qc_sample_names(
 
 // --- Helper for EigenSNP-Rust Ordered PCA SNP Metadata ---
 fn get_eigensnp_ordered_pca_snp_metadata(
-    preparer: &MicroarrayDataPreparer,      // From crate::prepare
-    original_indices_pca_snps: &[usize],  // From MicroarrayGenotypeAccessor in crate::prepare
+    preparer: &MicroarrayDataPreparer,   // From crate::prepare
+    original_indices_pca_snps: &[usize], // From MicroarrayGenotypeAccessor in crate::prepare
 ) -> Result<(Vec<String>, Vec<String>, Vec<u64>), Error> {
     let mut snp_ids = Vec::with_capacity(original_indices_pca_snps.len());
     let mut snp_chroms = Vec::with_capacity(original_indices_pca_snps.len());
@@ -483,7 +668,10 @@ fn get_eigensnp_ordered_pca_snp_metadata(
     let initial_positions = preparer.initial_bim_bp_positions_arc();
 
     for &original_idx in original_indices_pca_snps {
-        if original_idx >= initial_sids.len() || original_idx >= initial_chroms.len() || original_idx >= initial_positions.len() {
+        if original_idx >= initial_sids.len()
+            || original_idx >= initial_chroms.len()
+            || original_idx >= initial_positions.len()
+        {
             return Err(anyhow!(
                 "Original SNP index {} out of bounds for BIM metadata arrays (SIDs len {}, Chroms len {}, Pos len {}).",
                 original_idx, initial_sids.len(), initial_chroms.len(), initial_positions.len()
@@ -496,12 +684,11 @@ fn get_eigensnp_ordered_pca_snp_metadata(
     Ok((snp_ids, snp_chroms, snp_pos))
 }
 
-
 // --- Module Implementations ---
 
 mod cli {
-    use std::path::PathBuf;
     use clap::Parser;
+    use std::path::PathBuf;
 
     #[derive(Parser, Debug)]
     #[command(author, version, about = "Genomic PCA Tool from VCF or BED/LD-block files.", long_about = None, propagate_version = true)]
@@ -510,94 +697,207 @@ mod cli {
         #[arg(short, long = "out", required = true, help = "Output file prefix.")]
         pub(crate) output_prefix: String,
 
-        #[arg(short = 't', long, help = "Number of threads for parallel operations (default: all available CPUs).")]
+        #[arg(
+            short = 't',
+            long,
+            help = "Number of threads for parallel operations (default: all available CPUs)."
+        )]
         pub(crate) threads: Option<usize>,
 
-        #[arg(long, default_value = "Info", help = "Logging level (e.g., Off, Error, Warn, Info, Debug, Trace).")]
+        #[arg(
+            long,
+            default_value = "Info",
+            help = "Logging level (e.g., Off, Error, Warn, Info, Debug, Trace)."
+        )]
         pub(crate) log_level: String,
 
         // --- VCF Workflow Specific Arguments ---
-        #[arg(short = 'd', long = "vcf-dir", help = "Directory containing VCF files (required if not using --eigensnp).", required_unless_present("eigensnp"))]
+        #[arg(
+            short = 'd',
+            long = "vcf-dir",
+            help = "Directory containing VCF files (required if not using --eigensnp).",
+            required_unless_present("eigensnp")
+        )]
         pub(crate) vcf_dir: Option<PathBuf>,
 
-        #[arg(short = 'k', long, help = "Number of principal components to compute (for VCF workflow).", required_unless_present("eigensnp"))]
+        #[arg(
+            short = 'k',
+            long,
+            help = "Number of principal components to compute (for VCF workflow).",
+            required_unless_present("eigensnp")
+        )]
         pub(crate) components: Option<usize>,
 
-        #[arg(long, help = "Minimum Minor Allele Frequency (MAF) for VCF variant filtering (VCF workflow). If not set, defaults to 0.01 for VCF mode when processing.")]
+        #[arg(
+            long,
+            help = "Minimum Minor Allele Frequency (MAF) for VCF variant filtering (VCF workflow). If not set, defaults to 0.01 for VCF mode when processing."
+        )]
         pub(crate) maf: Option<f64>,
 
-        #[arg(long, help = "Seed for randomized SVD in efficient-pca (for VCF workflow).")]
+        #[arg(
+            long,
+            help = "Seed for randomized SVD in efficient-pca (for VCF workflow)."
+        )]
         pub(crate) rfit_seed: Option<u64>,
 
         // --- EigenSNP-Rust Workflow Flag ---
-        #[arg(long, help = "Run PCA using the EigenSNP-Rust algorithm (requires BED & LD block files).")]
+        #[arg(
+            long,
+            help = "Run PCA using the EigenSNP-Rust algorithm (requires BED & LD block files)."
+        )]
         pub(crate) eigensnp: bool,
 
         // --- EigenSNP-Rust Workflow Specific Arguments ---
-        #[arg(long, help="Path to the BED file (required if --eigensnp is used).", required_if_eq("eigensnp", "true"))]
+        #[arg(
+            long,
+            help = "Path to the BED file (required if --eigensnp is used).",
+            required_if_eq("eigensnp", "true")
+        )]
         pub(crate) bed_file: Option<PathBuf>,
 
-        #[arg(long, help="Path to the LD block definition file (required if --eigensnp is used).", required_if_eq("eigensnp", "true"))]
+        #[arg(
+            long,
+            help = "Path to the LD block definition file (required if --eigensnp is used).",
+            required_if_eq("eigensnp", "true")
+        )]
         pub(crate) ld_block_file: Option<PathBuf>,
 
-        #[arg(long, help="Optional: Path to a file listing sample IDs to keep (for --eigensnp).")]
+        #[arg(
+            long,
+            help = "Optional: Path to a file listing sample IDs to keep (for --eigensnp)."
+        )]
         pub(crate) eigensnp_sample_keep_file: Option<PathBuf>,
 
-        #[arg(long, help="Min SNP call rate for EigenSNP-Rust QC (default: 0.98 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("0.98")))]
+        #[arg(
+            long,
+            help = "Min SNP call rate for EigenSNP-Rust QC (default: 0.98 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("0.98"))
+        )]
         pub(crate) eigensnp_min_call_rate: Option<f64>,
 
-        #[arg(long, help="Min SNP MAF for EigenSNP-Rust QC (default: 0.01 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("0.01")))]
+        #[arg(
+            long,
+            help = "Min SNP MAF for EigenSNP-Rust QC (default: 0.01 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("0.01"))
+        )]
         pub(crate) eigensnp_min_maf: Option<f64>,
 
-        #[arg(long, help="Max SNP HWE p-value for EigenSNP-Rust QC (1.0 to disable; default: 1e-6 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("1e-6")))]
+        #[arg(
+            long,
+            help = "Max SNP HWE p-value for EigenSNP-Rust QC (1.0 to disable; default: 1e-6 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("1e-6"))
+        )]
         pub(crate) eigensnp_max_hwe_p: Option<f64>,
 
-        #[arg(long, help="Target number of global PCs for EigenSNP-Rust (default: 10 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("10")))]
+        #[arg(
+            long,
+            help = "Target number of global PCs for EigenSNP-Rust (default: 10 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("10"))
+        )]
         pub(crate) eigensnp_k_global: Option<usize>,
 
-        #[arg(long, help="Number of local components per LD block for EigenSNP-Rust (default: 7 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("7")))]
+        #[arg(
+            long,
+            help = "Number of local components per LD block for EigenSNP-Rust (default: 7 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("7"))
+        )]
         pub(crate) eigensnp_components_per_block: Option<usize>,
 
-        #[arg(long, help="Subset factor for local basis learning in EigenSNP-Rust (default: 0.075 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("0.075")))]
+        #[arg(
+            long,
+            help = "Subset factor for local basis learning in EigenSNP-Rust (default: 0.075 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("0.075"))
+        )]
         pub(crate) eigensnp_subset_factor: Option<f64>,
 
-        #[arg(long, help="Min subset size for local basis learning in EigenSNP-Rust (default: 10000 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("10000")))]
+        #[arg(
+            long,
+            help = "Min subset size for local basis learning in EigenSNP-Rust (default: 10000 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("10000"))
+        )]
         pub(crate) eigensnp_min_subset_size: Option<usize>,
 
-        #[arg(long, help="Max subset size for local basis learning in EigenSNP-Rust (default: 40000 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("40000")))]
+        #[arg(
+            long,
+            help = "Max subset size for local basis learning in EigenSNP-Rust (default: 40000 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("40000"))
+        )]
         pub(crate) eigensnp_max_subset_size: Option<usize>,
 
-        #[arg(long, help="Global PCA sketch oversampling for EigenSNP-Rust (default: 10 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("10")))]
+        #[arg(
+            long,
+            help = "Global PCA sketch oversampling for EigenSNP-Rust (default: 10 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("10"))
+        )]
         pub(crate) eigensnp_global_oversampling: Option<usize>,
 
-        #[arg(long, help="Global PCA power iterations for EigenSNP-Rust (default: 2 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("2")))]
+        #[arg(
+            long,
+            help = "Global PCA power iterations for EigenSNP-Rust (default: 2 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("2"))
+        )]
         pub(crate) eigensnp_global_power_iter: Option<usize>,
 
-        #[arg(long, help="Local RSVD sketch oversampling for EigenSNP-Rust (default: 10 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("10")))]
+        #[arg(
+            long,
+            help = "Local RSVD sketch oversampling for EigenSNP-Rust (default: 10 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("10"))
+        )]
         pub(crate) eigensnp_local_oversampling: Option<usize>,
 
-        #[arg(long, help="Local RSVD power iterations for EigenSNP-Rust (default: 2 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("2")))]
+        #[arg(
+            long,
+            help = "Local RSVD power iterations for EigenSNP-Rust (default: 2 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("2"))
+        )]
         pub(crate) eigensnp_local_power_iter: Option<usize>,
 
-        #[arg(long, help="Random seed for EigenSNP-Rust (default: 2025 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("2025")))]
+        #[arg(
+            long,
+            help = "Random seed for EigenSNP-Rust (default: 2025 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("2025"))
+        )]
         pub(crate) eigensnp_seed: Option<u64>,
 
-        #[arg(long, help="SNP processing strip size for EigenSNP-Rust (default: 2000 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("2000")))]
+        #[arg(
+            long,
+            help = "SNP processing strip size for EigenSNP-Rust (default: 2000 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("2000"))
+        )]
         pub(crate) eigensnp_snp_strip_size: Option<usize>,
 
-        #[arg(long, help="Number of refinement passes for EigenSNP-Rust (default: 1 when --eigensnp is active).", default_value_if("eigensnp", "true", Some("1")))]
+        #[arg(
+            long,
+            help = "Number of refinement passes for EigenSNP-Rust (default: 1 when --eigensnp is active).",
+            default_value_if("eigensnp", "true", Some("1"))
+        )]
         pub(crate) eigensnp_refine_passes: Option<usize>,
 
-        #[arg(long, help="Enable detailed diagnostics collection for EigenSNP-Rust (if library feature 'eigensnp-diagnostics' is active).")]
+        #[arg(
+            long = "save-local-pcs",
+            help = "For EigenSNP workflow: saves local PC loadings for each LD block to the specified directory.",
+            value_name = "DIR",
+            requires = "eigensnp"
+        )]
+        pub(crate) save_local_pcs: Option<PathBuf>,
+
+        #[arg(
+            long,
+            help = "Enable detailed diagnostics collection for EigenSNP-Rust (if library feature 'eigensnp-diagnostics' is active)."
+        )]
         pub(crate) eigensnp_collect_diagnostics: bool, // Defaults to false
 
-        #[arg(long = "no-filter", help = "Disable all optional SNP QC (MAF, HWE, Call Rate) for the EigenSNP workflow. Assumes data is pre-filtered and ready for PCA.")]
+        #[arg(
+            long = "no-filter",
+            help = "Disable all optional SNP QC (MAF, HWE, Call Rate) for the EigenSNP workflow. Assumes data is pre-filtered and ready for PCA."
+        )]
         pub(crate) no_filter: bool,
     }
 }
 
-mod pca_runner { // For VCF workflow
-    use super::{anyhow, warn, info, Result, Error, Array2, EfficientPcaModel, CliArgs};
+mod pca_runner {
+    // For VCF workflow
+    use super::{anyhow, info, warn, Array2, CliArgs, EfficientPcaModel, Error, Result};
 
     pub(crate) fn run_genomic_pca(
         genotype_matrix: Array2<f64>,
@@ -616,10 +916,15 @@ mod pca_runner { // For VCF workflow
         let num_features = genotype_matrix.ncols();
 
         if num_samples < 2 {
-            return Err(anyhow!("PCA requires at least 2 samples, found {}.", num_samples));
+            return Err(anyhow!(
+                "PCA requires at least 2 samples, found {}.",
+                num_samples
+            ));
         }
         if num_features == 0 {
-            return Err(anyhow!("PCA requires at least 1 variant (feature), found 0."));
+            return Err(anyhow!(
+                "PCA requires at least 1 variant (feature), found 0."
+            ));
         }
 
         let max_possible_k = num_samples.min(num_features);
@@ -631,7 +936,7 @@ mod pca_runner { // For VCF workflow
             k_requested_components = max_possible_k;
         }
         if k_requested_components == 0 {
-             return Err(anyhow!(
+            return Err(anyhow!(
                 "Effective number of components to request (k_requested_components) is 0 for matrix ({} samples x {} features). Cannot proceed.",
                 num_samples, num_features
             ));
@@ -640,14 +945,14 @@ mod pca_runner { // For VCF workflow
         let n_oversamples = 10; // A common default for randomized SVD
         let seed = cli_args.rfit_seed; // Pass through seed if provided
         let tolerance_rfit = None; // Use efficient-pca's default tolerance
-        
+
         let data_for_transform = genotype_matrix.clone(); // `rfit` consumes the matrix
 
         info!(
             "Running efficient_pca rfit: k_requested={}, n_oversamples={}, seed={:?}, rfit_tolerance=None",
             k_requested_components, n_oversamples, seed
         );
-        
+
         // The `rfit` method performs the PCA and stores loadings and explained variance internally.
         pca_model
             .rfit(
@@ -657,12 +962,21 @@ mod pca_runner { // For VCF workflow
                 seed,
                 tolerance_rfit,
             )
-            .map_err(|e| anyhow!("PCA computation with efficient-pca rfit failed: {}", e.to_string()))?;
-            
+            .map_err(|e| {
+                anyhow!(
+                    "PCA computation with efficient-pca rfit failed: {}",
+                    e.to_string()
+                )
+            })?;
+
         // `transform` applies the learned PCA to project data into the PC space.
-        let transformed_pcs = pca_model.transform(data_for_transform)
-            .map_err(|e| anyhow!("PCA transformation with efficient-pca failed after rfit: {}", e.to_string()))?;
-        
+        let transformed_pcs = pca_model.transform(data_for_transform).map_err(|e| {
+            anyhow!(
+                "PCA transformation with efficient-pca failed after rfit: {}",
+                e.to_string()
+            )
+        })?;
+
         let num_components_kept = transformed_pcs.ncols();
 
         if num_components_kept == 0 && k_requested_components > 0 {
@@ -684,9 +998,8 @@ mod pca_runner { // For VCF workflow
 }
 
 mod output_writer {
-    use super::{anyhow, info, warn, Result, Array2, File, BufWriter, Write};
+    use super::{anyhow, info, warn, Array2, BufWriter, File, Result, Write};
     // Array1 might be needed if directly writing from ndarray::Array1
-     
 
     // Helper to create output files.
     fn create_output_file(prefix: &str, suffix: &str) -> Result<BufWriter<File>> {
@@ -707,7 +1020,10 @@ mod output_writer {
             return Ok(());
         }
         let mut writer = create_output_file(output_prefix, "vcf.pca.tsv")?; // Distinguish from EigenSNP output
-        info!("Writing f64 principal components (VCF workflow) to {}.vcf.pca.tsv", output_prefix);
+        info!(
+            "Writing f64 principal components (VCF workflow) to {}.vcf.pca.tsv",
+            output_prefix
+        );
 
         write!(writer, "SampleID")?;
         for i in 1..=transformed_pcs.ncols() {
@@ -724,7 +1040,9 @@ mod output_writer {
             } else {
                 // This case should ideally not happen if sample_names and transformed_pcs correspond correctly.
                 warn!("Sample index {} out of bounds for f64 PCs ({} rows). Writing NA for remaining PCs for this sample.", sample_idx, transformed_pcs.nrows());
-                 for _ in 0..transformed_pcs.ncols() { write!(writer, "\tNA")?; }
+                for _ in 0..transformed_pcs.ncols() {
+                    write!(writer, "\tNA")?;
+                }
             }
             writeln!(writer)?;
         }
@@ -742,7 +1060,10 @@ mod output_writer {
             return Ok(());
         }
         let mut writer = create_output_file(output_prefix, "eigensnp.pca.tsv")?;
-        info!("Writing f32 principal components (EigenSNP-Rust workflow) to {}.eigensnp.pca.tsv", output_prefix);
+        info!(
+            "Writing f32 principal components (EigenSNP-Rust workflow) to {}.eigensnp.pca.tsv",
+            output_prefix
+        );
 
         write!(writer, "SampleID")?;
         for i in 1..=transformed_pcs_f32.ncols() {
@@ -758,7 +1079,9 @@ mod output_writer {
                 }
             } else {
                 warn!("Sample index {} out of bounds for f32 PCs ({} rows). Writing NA for remaining PCs for this sample.", sample_idx, transformed_pcs_f32.nrows());
-                 for _ in 0..transformed_pcs_f32.ncols() { write!(writer, "\tNA")?; }
+                for _ in 0..transformed_pcs_f32.ncols() {
+                    write!(writer, "\tNA")?;
+                }
             }
             writeln!(writer)?;
         }
@@ -766,10 +1089,7 @@ mod output_writer {
     }
 
     // Writes eigenvalues (common for both workflows if data is &[f64]).
-    pub(crate) fn write_eigenvalues(
-        output_prefix: &str,
-        pc_variances: &[f64],
-    ) -> Result<()> {
+    pub(crate) fn write_eigenvalues(output_prefix: &str, pc_variances: &[f64]) -> Result<()> {
         if pc_variances.is_empty() {
             info!("No eigenvalues to write.");
             // Create an empty file with header for consistency if desired, or just return.
@@ -792,7 +1112,7 @@ mod output_writer {
         output_prefix: &str,
         variant_ids: &[String],
         chromosomes: &[String],
-        positions: &[u64],       // 
+        positions: &[u64], //
         loadings_matrix_f32: &Array2<f32>,
     ) -> Result<()> {
         if loadings_matrix_f32.ncols() == 0 {
@@ -804,12 +1124,17 @@ mod output_writer {
             // Create an empty file with header for consistency if desired.
             let mut writer = create_output_file(output_prefix, "eigensnp.loadings.tsv")?;
             write!(writer, "VariantID\tChrom\tPos")?;
-            for i in 1..=loadings_matrix_f32.ncols() { write!(writer, "\tPC{}_loading", i)?; }
+            for i in 1..=loadings_matrix_f32.ncols() {
+                write!(writer, "\tPC{}_loading", i)?;
+            }
             writeln!(writer)?;
             return Ok(());
         }
         let mut writer = create_output_file(output_prefix, "eigensnp.loadings.tsv")?;
-        info!("Writing f32 SNP loadings (EigenSNP-Rust workflow) to {}.eigensnp.loadings.tsv", output_prefix);
+        info!(
+            "Writing f32 SNP loadings (EigenSNP-Rust workflow) to {}.eigensnp.loadings.tsv",
+            output_prefix
+        );
 
         write!(writer, "VariantID\tChrom\tPos")?;
         for i in 1..=loadings_matrix_f32.ncols() {
@@ -818,9 +1143,10 @@ mod output_writer {
         writeln!(writer)?;
 
         // variant metadata arrays have same length as loadings matrix rows
-        if !(variant_ids.len() == loadings_matrix_f32.nrows() && 
-             chromosomes.len() == loadings_matrix_f32.nrows() &&
-             positions.len() == loadings_matrix_f32.nrows()) {
+        if !(variant_ids.len() == loadings_matrix_f32.nrows()
+            && chromosomes.len() == loadings_matrix_f32.nrows()
+            && positions.len() == loadings_matrix_f32.nrows())
+        {
             return Err(anyhow!(
                 "Mismatch in lengths of variant metadata and loadings matrix rows. VariantIDs: {}, Chroms: {}, Pos: {}, LoadingsRows: {}",
                 variant_ids.len(), chromosomes.len(), positions.len(), loadings_matrix_f32.nrows()
@@ -835,7 +1161,11 @@ mod output_writer {
                 variant_ids[variant_idx], chromosomes[variant_idx], positions[variant_idx]
             )?;
             for pc_idx in 0..loadings_matrix_f32.ncols() {
-                write!(writer, "\t{:.6}", loadings_matrix_f32[[variant_idx, pc_idx]])?;
+                write!(
+                    writer,
+                    "\t{:.6}",
+                    loadings_matrix_f32[[variant_idx, pc_idx]]
+                )?;
             }
             writeln!(writer)?;
         }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -1,5 +1,3 @@
-use std::simd::{Simd, Mask, StdFloat};
-use std::simd::prelude::*;
 use flume;
 use log::{debug, error, info, warn};
 use ndarray::{Array1, Array2};
@@ -7,14 +5,16 @@ use num_cpus;
 use rayon::prelude::*;
 use statrs::distribution::{ChiSquared, ContinuousCDF};
 use std::collections::{HashMap, HashSet};
+use std::simd::num::SimdUint;
+use std::simd::prelude::*;
+use std::simd::{Mask, Simd, StdFloat};
 use std::sync::{Arc, PoisonError};
 use thiserror::Error;
-use std::simd::num::SimdUint;
 
 // SIMD Lane constants
 // Target 256-bit SIMD (AVX2 equivalent)
 const TARGET_SIMD_BYTES: usize = 32; // 256 bits / 8 bits_per_byte
-const ACTUAL_LANES_I8: usize = TARGET_SIMD_BYTES / std::mem::size_of::<i8>();   // 32
+const ACTUAL_LANES_I8: usize = TARGET_SIMD_BYTES / std::mem::size_of::<i8>(); // 32
 const ACTUAL_LANES_F32: usize = TARGET_SIMD_BYTES / std::mem::size_of::<f32>(); // 8
 
 // bed_reader imports
@@ -31,7 +31,10 @@ pub enum DataPrepError {
     Io(#[from] std::io::Error),
 
     #[error("BED reader error: {source}")]
-    Bed { #[from] source: Box<BedErrorPlus> },
+    Bed {
+        #[from]
+        source: Box<BedErrorPlus>,
+    },
 
     #[error("Integer parsing error: {0}")]
     ParseInt(#[from] std::num::ParseIntError),
@@ -108,9 +111,13 @@ impl<T> From<PoisonError<T>> for DataPrepError {
 }
 
 pub trait WrapErr<T, EOriginal>
-where EOriginal: std::error::Error + Send + Sync + 'static
+where
+    EOriginal: std::error::Error + Send + Sync + 'static,
 {
-    fn wrap_err_with_context(self, context_fn: impl FnOnce() -> String) -> Result<T, ThreadSafeStdError>;
+    fn wrap_err_with_context(
+        self,
+        context_fn: impl FnOnce() -> String,
+    ) -> Result<T, ThreadSafeStdError>;
     fn wrap_err_with_str(self, context: &str) -> Result<T, ThreadSafeStdError>;
 }
 
@@ -118,7 +125,10 @@ impl<T, EOriginal> WrapErr<T, EOriginal> for Result<T, EOriginal>
 where
     EOriginal: std::error::Error + Send + Sync + 'static,
 {
-    fn wrap_err_with_context(self, context_fn: impl FnOnce() -> String) -> Result<T, ThreadSafeStdError> {
+    fn wrap_err_with_context(
+        self,
+        context_fn: impl FnOnce() -> String,
+    ) -> Result<T, ThreadSafeStdError> {
         self.map_err(|e_original| {
             Box::new(DataPrepError::Contextual {
                 context: context_fn(),
@@ -171,7 +181,7 @@ mod io_service_infrastructure {
     use super::*;
     use flume;
     use log::{debug, error, info, warn};
-    use ndarray::{Array2};
+    use ndarray::Array2;
     use std::collections::HashMap;
     use std::collections::VecDeque;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
@@ -234,7 +244,8 @@ mod io_service_infrastructure {
     pub(crate) struct IoService {
         pub(crate) bed_file_path: Arc<String>,
         pub(crate) request_tx: flume::Sender<IoRequest>,
-        pub(crate) request_rx_shared_for_actors_and_controller_monitoring: flume::Receiver<IoRequest>,
+        pub(crate) request_rx_shared_for_actors_and_controller_monitoring:
+            flume::Receiver<IoRequest>,
         pub(crate) metrics_tx_for_actors_to_controller: flume::Sender<IoTaskMetrics>,
         pub(crate) metrics_rx_for_controller: flume::Receiver<IoTaskMetrics>,
         pub(crate) active_actors: Arc<Mutex<HashMap<usize /*actor_id*/, IoActorHandle>>>,
@@ -249,7 +260,8 @@ mod io_service_infrastructure {
     /// Justifications are based on common heuristics; optimal values may be system-dependent.
     pub(crate) const MIN_OPERATIONAL_IO_ACTORS: usize = 1;
     pub(crate) const CONTROLLER_ADJUSTMENT_INTERVAL: Duration = Duration::from_millis(750);
-    pub(crate) const CONTROLLER_THROUGHPUT_HISTORY_WINDOW_DURATION: Duration = Duration::from_secs(8); // e.g. ~10x adjustment interval
+    pub(crate) const CONTROLLER_THROUGHPUT_HISTORY_WINDOW_DURATION: Duration =
+        Duration::from_secs(8); // e.g. ~10x adjustment interval
     pub(crate) const TARGET_QUEUE_LENGTH_PER_ACTOR: usize = 3;
     pub(crate) const ACTOR_SCALING_STEP_SIZE: usize = 1;
     pub(crate) const CONTROLLER_SCALING_COOLDOWN_PERIOD: Duration = Duration::from_millis(2000);
@@ -264,24 +276,31 @@ mod io_service_infrastructure {
                 absolute_max_actors
             );
 
-            let request_channel_capacity = (absolute_max_actors.saturating_mul(TARGET_QUEUE_LENGTH_PER_ACTOR).saturating_mul(3)).max(1);
+            let request_channel_capacity = (absolute_max_actors
+                .saturating_mul(TARGET_QUEUE_LENGTH_PER_ACTOR)
+                .saturating_mul(3))
+            .max(1);
             let metrics_channel_capacity = (absolute_max_actors.saturating_mul(20)).max(1);
             info!(
                 "IoService: Request channel capacity: {}, Metrics channel capacity: {}",
                 request_channel_capacity, metrics_channel_capacity
             );
 
-            let (request_tx, request_rx_shared) = flume::bounded::<IoRequest>(request_channel_capacity);
-            let (metrics_tx, metrics_rx) = flume::bounded::<IoTaskMetrics>(metrics_channel_capacity);
+            let (request_tx, request_rx_shared) =
+                flume::bounded::<IoRequest>(request_channel_capacity);
+            let (metrics_tx, metrics_rx) =
+                flume::bounded::<IoTaskMetrics>(metrics_channel_capacity);
 
             // Set initial target actors to a more responsive number, e.g., number of logical CPUs,
             // but capped by absolute_max_actors and at least 1.
             // This helps in utilizing resources better from the start for chunked I/O.
             let desired_initial_actors = num_cpus::get(); // Get number of logical CPUs
-            // MIN_OPERATIONAL_IO_ACTORS is 1, as defined in io_service_controller_loop.
-            // Using 1 directly here for clarity as the const is not in scope.
+                                                          // MIN_OPERATIONAL_IO_ACTORS is 1, as defined in io_service_controller_loop.
+                                                          // Using 1 directly here for clarity as the const is not in scope.
             const MIN_OP_ACTORS_FOR_INIT: usize = 1;
-            let initial_target_actors = desired_initial_actors.max(MIN_OP_ACTORS_FOR_INIT).min(absolute_max_actors);
+            let initial_target_actors = desired_initial_actors
+                .max(MIN_OP_ACTORS_FOR_INIT)
+                .min(absolute_max_actors);
             info!(
                 "IoService: Initial target actors set to {}",
                 initial_target_actors
@@ -322,8 +341,14 @@ mod io_service_infrastructure {
             }
 
             for i in 0..successfully_spawned_count {
-                match init_status_rx.recv_timeout(Duration::from_secs(10))
-                    .wrap_err_with_context(|| format!("IoService: Timed out waiting for actor {} init to report status.", i))? {
+                match init_status_rx
+                    .recv_timeout(Duration::from_secs(10))
+                    .wrap_err_with_context(|| {
+                        format!(
+                            "IoService: Timed out waiting for actor {} init to report status.",
+                            i
+                        )
+                    })? {
                     IoResponse::ActorInitStatus {
                         actor_id,
                         success,
@@ -333,8 +358,7 @@ mod io_service_infrastructure {
                             let err_message = error_msg.unwrap_or_default();
                             error!(
                                 "IoService: Initial actor {} failed to initialize: {:?}",
-                                actor_id,
-                                err_message
+                                actor_id, err_message
                             );
                             service_arc.shutdown_all_actors_and_controller_immediately();
                             return Err(Box::new(DataPrepError::Message(format!(
@@ -368,8 +392,12 @@ mod io_service_infrastructure {
                 .spawn(move || io_service_controller_thread(controller_service_arc_clone))
             {
                 Ok(handle) => {
-                    *service_arc.controller_join_handle.lock()
-                        .map_err(|e| DataPrepError::MutexPoisoned(format!("IoService: Controller join handle mutex poisoned during spawn: {}", e)))? = Some(handle);
+                    *service_arc.controller_join_handle.lock().map_err(|e| {
+                        DataPrepError::MutexPoisoned(format!(
+                            "IoService: Controller join handle mutex poisoned during spawn: {}",
+                            e
+                        ))
+                    })? = Some(handle);
                     info!("IoService: Controller thread spawned successfully.");
                 }
                 Err(e) => {
@@ -386,7 +414,10 @@ mod io_service_infrastructure {
             &self,
             init_status_tx: Option<flume::Sender<IoResponse>>,
         ) -> bool {
-            let mut active_actors_guard = self.active_actors.lock().expect("Mutex poisoned: active_actors lock in spawn_new_actor_internal");
+            let mut active_actors_guard = self
+                .active_actors
+                .lock()
+                .expect("Mutex poisoned: active_actors lock in spawn_new_actor_internal");
 
             if active_actors_guard.len() >= self.absolute_max_actors {
                 warn!(
@@ -409,7 +440,8 @@ mod io_service_infrastructure {
             let thread_builder = std::thread::Builder::new().name(format!("io_actor_{}", actor_id));
 
             match thread_builder.spawn(move || {
-                io_reader_actor_loop( // Note: Name targeted by prior subtask
+                io_reader_actor_loop(
+                    // Note: Name targeted by prior subtask
                     actor_id,
                     bed_path_clone,
                     request_rx_clone,
@@ -442,7 +474,10 @@ mod io_service_infrastructure {
         }
 
         fn shutdown_one_actor(&self) -> bool {
-            let mut active_actors_guard = self.active_actors.lock().expect("Mutex poisoned: active_actors lock in shutdown_one_actor");
+            let mut active_actors_guard = self
+                .active_actors
+                .lock()
+                .expect("Mutex poisoned: active_actors lock in shutdown_one_actor");
             if active_actors_guard.is_empty() {
                 return false;
             }
@@ -478,7 +513,8 @@ mod io_service_infrastructure {
         }
     }
 
-    fn io_reader_actor_loop( // Note: Name targeted by prior subtask
+    fn io_reader_actor_loop(
+        // Note: Name targeted by prior subtask
         actor_id: usize,
         bed_file_path: Arc<String>,
         request_rx: flume::Receiver<IoRequest>,
@@ -553,28 +589,21 @@ mod io_service_infrastructure {
             let selected_event: SelectOutcome;
             {
                 let selector = flume::select::Selector::new()
-                    .recv(&individual_shutdown_rx, |result| {
-                        match result {
-                            Ok(_) => SelectOutcome::IndividualShutdown,
-                            Err(flume::RecvError::Disconnected) => {
-                                debug!(
-                                    "IoActor [{}]: Individual shutdown channel disconnected.",
-                                    actor_id
-                                );
-                                SelectOutcome::IndividualShutdown
-                            }
+                    .recv(&individual_shutdown_rx, |result| match result {
+                        Ok(_) => SelectOutcome::IndividualShutdown,
+                        Err(flume::RecvError::Disconnected) => {
+                            debug!(
+                                "IoActor [{}]: Individual shutdown channel disconnected.",
+                                actor_id
+                            );
+                            SelectOutcome::IndividualShutdown
                         }
                     })
-                    .recv(&request_rx, |result| {
-                        match result {
-                            Ok(request) => SelectOutcome::RequestReceived(request),
-                            Err(flume::RecvError::Disconnected) => {
-                                debug!(
-                                    "IoActor [{}]: Main request channel disconnected.",
-                                    actor_id
-                                );
-                                SelectOutcome::RequestChannelDisconnected
-                            }
+                    .recv(&request_rx, |result| match result {
+                        Ok(request) => SelectOutcome::RequestReceived(request),
+                        Err(flume::RecvError::Disconnected) => {
+                            debug!("IoActor [{}]: Main request channel disconnected.", actor_id);
+                            SelectOutcome::RequestChannelDisconnected
                         }
                     });
 
@@ -611,10 +640,8 @@ mod io_service_infrastructure {
                         } => {
                             let qc_sample_indices_slice: &[isize] = qc_sample_indices.as_slice();
                             // Convert original_m_indices (Vec<usize>) to Vec<isize> for bed_reader
-                            let original_m_indices_isize: Vec<isize> = original_m_indices
-                                .iter()
-                                .map(|&idx| idx as isize)
-                                .collect();
+                            let original_m_indices_isize: Vec<isize> =
+                                original_m_indices.iter().map(|&idx| idx as isize).collect();
 
                             // Read an entire chunk of SNPs.
                             // Request C-order to get data as (samples, snps_in_chunk),
@@ -624,7 +651,7 @@ mod io_service_infrastructure {
                                 .sid_index(original_m_indices_isize.as_slice()) // Pass the chunk of SIDs
                                 .iid_index(qc_sample_indices_slice)
                                 .i8() // Output as i8, suitable for dosage
-                                .f()  // Request F-order: (SNPs_in_chunk x samples), where SNPs are rows and contiguous
+                                .f() // Request F-order: (SNPs_in_chunk x samples), where SNPs are rows and contiguous
                                 .count_a1() // Standard allele counting
                                 .num_threads(0) // Allow bed-reader to use its internal default Rayon parallelism
                                 .read(&mut bed_reader_instance);
@@ -633,9 +660,14 @@ mod io_service_infrastructure {
                                 Ok(array_samples_x_snps_in_chunk) => {
                                     // array_samples_x_snps_in_chunk has dimensions (num_qc_samples, original_m_indices.len())
                                     // Estimate bytes read for the chunk. This is an approximation of packed BED size.
-                                    bytes_read_for_task = (array_samples_x_snps_in_chunk.nrows() * array_samples_x_snps_in_chunk.ncols() + 3) / 4;
+                                    bytes_read_for_task = (array_samples_x_snps_in_chunk.nrows()
+                                        * array_samples_x_snps_in_chunk.ncols()
+                                        + 3)
+                                        / 4;
                                     IoResponse::RawSnpChunkForQc {
-                                        raw_genotypes_i8_chunk_result: Ok(array_samples_x_snps_in_chunk),
+                                        raw_genotypes_i8_chunk_result: Ok(
+                                            array_samples_x_snps_in_chunk,
+                                        ),
                                         // Clone original_m_indices here to transfer ownership of the clone to the response,
                                         // while the original original_m_indices remains in scope for subsequent logging.
                                         original_m_indices_in_chunk: original_m_indices.clone(),
@@ -644,7 +676,9 @@ mod io_service_infrastructure {
                                 Err(e) => {
                                     // These logging lines can safely borrow original_m_indices as it has not been moved yet.
                                     let num_snps_in_failed_chunk = original_m_indices.len();
-                                    let first_snp_idx_in_failed_chunk = original_m_indices.first().map_or_else(|| "N/A".to_string(), |v| v.to_string());
+                                    let first_snp_idx_in_failed_chunk = original_m_indices
+                                        .first()
+                                        .map_or_else(|| "N/A".to_string(), |v| v.to_string());
                                     warn!(
                                         "IoActor [{}]: Bed read failed for GetSnpChunkForQc ({} SNPs, starting original_idx {}): {:?}",
                                         actor_id, num_snps_in_failed_chunk, first_snp_idx_in_failed_chunk, e
@@ -661,10 +695,11 @@ mod io_service_infrastructure {
                             };
                             // The `response` now owns a clone of `original_m_indices`. The `original_m_indices`
                             // in this function's scope is still valid and can be borrowed below.
-                            if response_tx.send(response).is_err()
-                            {
+                            if response_tx.send(response).is_err() {
                                 // This borrow of original_m_indices is now safe.
-                                let first_snp_idx_in_dropped_chunk = original_m_indices.first().map_or_else(|| "N/A".to_string(), |v| v.to_string());
+                                let first_snp_idx_in_dropped_chunk = original_m_indices
+                                    .first()
+                                    .map_or_else(|| "N/A".to_string(), |v| v.to_string());
                                 debug!(
                                     "IoActor [{}]: Failed to send RawSnpChunkForQc response for chunk starting with original_idx {}. Receiver likely dropped.",
                                     actor_id, first_snp_idx_in_dropped_chunk
@@ -690,7 +725,11 @@ mod io_service_infrastructure {
                             let raw_i8_block_result = match read_result {
                                 Ok(array_samples_x_snps) => {
                                     // Approx bytes based on genotype dimensions: (num_samples * num_snps + 3) / 4 bytes per genotype (packed BED estimate, ceiling division).
-                                    bytes_read_for_task = (array_samples_x_snps.len_of(ndarray::Axis(0)) * array_samples_x_snps.len_of(ndarray::Axis(1)) + 3) / 4;
+                                    bytes_read_for_task = (array_samples_x_snps
+                                        .len_of(ndarray::Axis(0))
+                                        * array_samples_x_snps.len_of(ndarray::Axis(1))
+                                        + 3)
+                                        / 4;
                                     Ok(array_samples_x_snps.t().as_standard_layout().to_owned())
                                 }
                                 Err(e) => {
@@ -713,10 +752,16 @@ mod io_service_infrastructure {
                     }) {
                         Ok(_) => {}
                         Err(flume::TrySendError::Full(_)) => {
-                            warn!("IoActor [{}]: Metrics channel full. Discarding metric.", actor_id);
+                            warn!(
+                                "IoActor [{}]: Metrics channel full. Discarding metric.",
+                                actor_id
+                            );
                         }
                         Err(flume::TrySendError::Disconnected(_)) => {
-                            debug!("IoActor [{}]: Failed to send metrics. Controller might be down.", actor_id);
+                            debug!(
+                                "IoActor [{}]: Failed to send metrics. Controller might be down.",
+                                actor_id
+                            );
                         }
                     }
                 }
@@ -731,7 +776,8 @@ mod io_service_infrastructure {
         info!("IoActor [{}]: Exiting run loop.", actor_id);
     }
 
-    fn io_service_controller_thread(service_arc: Arc<IoService>) { // Note: Name targeted by prior subtask
+    fn io_service_controller_thread(service_arc: Arc<IoService>) {
+        // Note: Name targeted by prior subtask
         info!(
             "IoController: Starting for service with bed file: {}",
             service_arc.bed_file_path
@@ -773,7 +819,11 @@ mod io_service_infrastructure {
             if last_adjustment_time.elapsed() >= CONTROLLER_ADJUSTMENT_INTERVAL
                 && last_scaling_event_time.elapsed() >= CONTROLLER_SCALING_COOLDOWN_PERIOD
             {
-                let current_live_actors = service_arc.active_actors.lock().expect("Mutex poisoned: active_actors lock in controller").len();
+                let current_live_actors = service_arc
+                    .active_actors
+                    .lock()
+                    .expect("Mutex poisoned: active_actors lock in controller")
+                    .len();
                 let prev_target_actors = service_arc
                     .current_target_actors
                     .load(AtomicOrdering::Relaxed);
@@ -895,7 +945,10 @@ mod io_service_infrastructure {
 
                     for actor_id in actor_ids {
                         if let Some(actor_handle) = active_actors_guard.remove(&actor_id) {
-                            info!("IoService: Sending shutdown signal to actor {}...", actor_id);
+                            info!(
+                                "IoService: Sending shutdown signal to actor {}...",
+                                actor_id
+                            );
                             if let Err(e) = actor_handle.shutdown_tx.send(()) {
                                 warn!("IoService: Failed to send shutdown to actor {}: {}. May have already exited.", actor_id, e);
                             }
@@ -938,8 +991,13 @@ impl MicroarrayDataPreparer {
         let initial_sample_ids_from_fam: Arc<Array1<String>>;
 
         {
-            let mut bed_for_metadata = Bed::new(&config.bed_file_path)
-                .wrap_err_with_context(|| format!("Failed to open BED file '{}' for initial metadata", config.bed_file_path))?;
+            let mut bed_for_metadata =
+                Bed::new(&config.bed_file_path).wrap_err_with_context(|| {
+                    format!(
+                        "Failed to open BED file '{}' for initial metadata",
+                        config.bed_file_path
+                    )
+                })?;
 
             initial_bim_sids = Arc::new(
                 bed_for_metadata
@@ -959,9 +1017,11 @@ impl MicroarrayDataPreparer {
                     .wrap_err_with_str("Failed to read bp_positions from BIM for initial metadata")?
                     .to_owned(),
             );
-            initial_snp_count_from_bim = bed_for_metadata.sid_count()
+            initial_snp_count_from_bim = bed_for_metadata
+                .sid_count()
                 .wrap_err_with_str("Failed to read sid_count for initial metadata")?;
-            initial_sample_count_from_fam = bed_for_metadata.iid_count()
+            initial_sample_count_from_fam = bed_for_metadata
+                .iid_count()
                 .wrap_err_with_str("Failed to read iid_count for initial metadata")?;
             initial_sample_ids_from_fam = Arc::new(
                 bed_for_metadata
@@ -1008,7 +1068,10 @@ impl MicroarrayDataPreparer {
 
         let (original_indices_of_qc_samples_vec, num_qc_samples) = self.perform_sample_qc()?;
         if num_qc_samples == 0 {
-            return Err(Box::new(DataPrepError::Message("No samples passed QC.".to_string())) as ThreadSafeStdError);
+            return Err(
+                Box::new(DataPrepError::Message("No samples passed QC.".to_string()))
+                    as ThreadSafeStdError,
+            );
         }
 
         let original_indices_of_qc_samples_arc = Arc::new(original_indices_of_qc_samples_vec);
@@ -1024,7 +1087,9 @@ impl MicroarrayDataPreparer {
         )?;
         if final_qc_snps_details.is_empty() {
             // This message is generic enough for both cases (with or without QC)
-            return Err(Box::new(DataPrepError::Message("No SNPs available for PCA after SNP processing step.".to_string())) as ThreadSafeStdError);
+            return Err(Box::new(DataPrepError::Message(
+                "No SNPs available for PCA after SNP processing step.".to_string(),
+            )) as ThreadSafeStdError);
         }
 
         let (
@@ -1104,7 +1169,8 @@ impl MicroarrayDataPreparer {
 
     /// Performs SNP quality control (call rate, MAF, HWE) if requested, and calculates standardization parameters (mean, std dev)
     /// using the IoService for batched BED file reading.
-    fn process_snps_and_qc( // Renamed function
+    fn process_snps_and_qc(
+        // Renamed function
         &self,
         original_indices_of_qc_samples_arc: &Arc<Vec<isize>>,
         num_qc_samples: usize,
@@ -1143,8 +1209,9 @@ impl MicroarrayDataPreparer {
 
         // Iterate over chunks of original SNP indices to create I/O requests.
         // Each iteration processes one I/O chunk: sends request, waits for response, then QCs SNPs in response.
-        for (io_chunk_idx, original_m_indices_for_current_io_chunk) in
-            original_snp_indices_0_based.chunks(SNP_IO_CHUNK_SIZE).enumerate()
+        for (io_chunk_idx, original_m_indices_for_current_io_chunk) in original_snp_indices_0_based
+            .chunks(SNP_IO_CHUNK_SIZE)
+            .enumerate()
         {
             let (response_tx, response_rx) = flume::bounded(1);
             let request = io_service_infrastructure::IoRequest::GetSnpChunkForQc {
@@ -1185,13 +1252,15 @@ impl MicroarrayDataPreparer {
                             if genotypes_for_chunk_samples_x_snps.nrows() != num_qc_samples {
                                 warn!("SNP QC (I/O chunk {}): Received data for {} samples (rows), but num_qc_samples indicates {}. Mismatch, skipping this chunk.",
                                        io_chunk_idx, genotypes_for_chunk_samples_x_snps.nrows(), num_qc_samples);
-                                 continue; // Skip to the next I/O chunk
+                                continue; // Skip to the next I/O chunk
                             }
                             // Number of columns should be number of SNPs in the chunk
-                            if genotypes_for_chunk_samples_x_snps.ncols() != original_m_indices_in_chunk.len() {
+                            if genotypes_for_chunk_samples_x_snps.ncols()
+                                != original_m_indices_in_chunk.len()
+                            {
                                 warn!("SNP QC (I/O chunk {}): Received data for {} SNPs (columns), but original_m_indices_in_chunk indicates {}. Mismatch, skipping this chunk.",
                                        io_chunk_idx, genotypes_for_chunk_samples_x_snps.ncols(), original_m_indices_in_chunk.len());
-                                 continue; // Skip to the next I/O chunk
+                                continue; // Skip to the next I/O chunk
                             }
 
                             // Parallelize QC over SNPs within this fetched chunk using Rayon.
@@ -1590,12 +1659,18 @@ impl MicroarrayDataPreparer {
         use std::fs::File;
         use std::io::{BufRead, BufReader};
         info!("Parsing LD block file: {}", self.config.ld_block_file_path);
-        let file = File::open(&self.config.ld_block_file_path)
-            .wrap_err_with_context(|| format!("Failed to open LD block file '{}'", self.config.ld_block_file_path))?;
+        let file = File::open(&self.config.ld_block_file_path).wrap_err_with_context(|| {
+            format!(
+                "Failed to open LD block file '{}'",
+                self.config.ld_block_file_path
+            )
+        })?;
         let reader = BufReader::new(file);
         let mut blocks = Vec::new();
         for (line_num, line_result) in reader.lines().enumerate() {
-            let line = line_result.wrap_err_with_context(|| format!("Error reading line {} from LD block file", line_num + 1))?;
+            let line = line_result.wrap_err_with_context(|| {
+                format!("Error reading line {} from LD block file", line_num + 1)
+            })?;
             let trimmed_line = line.trim();
             if trimmed_line.is_empty()
                 || trimmed_line.starts_with('#')
@@ -1606,16 +1681,27 @@ impl MicroarrayDataPreparer {
             }
 
             let parts: Vec<&str> = trimmed_line.split_whitespace().collect();
-            if parts.len() < 3 { // Expect at least 3 fields for chr, start, end.
+            if parts.len() < 3 {
+                // Expect at least 3 fields for chr, start, end.
                 warn!("Skipping malformed LD block line {}: '{}' (expected at least 3 fields: chr start end)", line_num + 1, line);
                 continue;
             }
             let chr_str_original = parts[0];
             let chr_str = Self::normalize_chromosome_name(chr_str_original);
-            let start_pos = parts[1].parse::<i32>()
-                .wrap_err_with_context(|| format!("LD block line {}: Error parsing start pos '{}'", line_num + 1, parts[1]))?;
-            let end_pos = parts[2].parse::<i32>()
-                .wrap_err_with_context(|| format!("LD block line {}: Error parsing end pos '{}'", line_num + 1, parts[2]))?;
+            let start_pos = parts[1].parse::<i32>().wrap_err_with_context(|| {
+                format!(
+                    "LD block line {}: Error parsing start pos '{}'",
+                    line_num + 1,
+                    parts[1]
+                )
+            })?;
+            let end_pos = parts[2].parse::<i32>().wrap_err_with_context(|| {
+                format!(
+                    "LD block line {}: Error parsing end pos '{}'",
+                    line_num + 1,
+                    parts[2]
+                )
+            })?;
 
             // Auto-generate a block ID based on chromosome and coordinates.
             let block_id_str = format!("{}:{}-{}", chr_str, start_pos, end_pos);
@@ -1625,7 +1711,10 @@ impl MicroarrayDataPreparer {
         if blocks.is_empty() {
             warn!("No valid LD blocks parsed from file: {}. Make sure format is chr start end (whitespace separated). Block IDs are auto-generated.", self.config.ld_block_file_path);
         } else {
-            info!("Successfully parsed {} LD blocks from file. Block IDs were auto-generated.", blocks.len());
+            info!(
+                "Successfully parsed {} LD blocks from file. Block IDs were auto-generated.",
+                blocks.len()
+            );
         }
         Ok(blocks)
     }
@@ -1667,14 +1756,18 @@ impl MicroarrayDataPreparer {
         observed_heterozygous_count: usize,
         observed_homozygous_allele2_count: usize,
     ) -> f64 {
-        let total_samples_with_genotypes = observed_homozygous_allele1_count + observed_heterozygous_count + observed_homozygous_allele2_count;
+        let total_samples_with_genotypes = observed_homozygous_allele1_count
+            + observed_heterozygous_count
+            + observed_homozygous_allele2_count;
         if total_samples_with_genotypes == 0 {
             warn!("HWE Test: Total samples (0) is effectively zero. Cannot compute HWE p-value. Returning 1.0.");
             return 1.0;
         }
 
-        let count_allele1 = 2.0 * observed_homozygous_allele1_count as f64 + observed_heterozygous_count as f64;
-        let count_allele2 = 2.0 * observed_homozygous_allele2_count as f64 + observed_heterozygous_count as f64;
+        let count_allele1 =
+            2.0 * observed_homozygous_allele1_count as f64 + observed_heterozygous_count as f64;
+        let count_allele2 =
+            2.0 * observed_homozygous_allele2_count as f64 + observed_heterozygous_count as f64;
         let total_alleles_observed = count_allele1 + count_allele2;
 
         if total_alleles_observed <= 1e-9 {
@@ -1718,9 +1811,9 @@ impl MicroarrayDataPreparer {
 
         if chi_squared_statistic.is_finite() {
             if expected_heterozygous > MIN_EXPECTED_FOR_DIVISION {
-                chi_squared_statistic += (observed_heterozygous_count as f64 - expected_heterozygous)
-                    .powi(2)
-                    / expected_heterozygous;
+                chi_squared_statistic +=
+                    (observed_heterozygous_count as f64 - expected_heterozygous).powi(2)
+                        / expected_heterozygous;
             } else if (observed_heterozygous_count as f64) > MIN_EXPECTED_FOR_DIVISION {
                 chi_squared_statistic = f64::INFINITY;
             }
@@ -1728,9 +1821,10 @@ impl MicroarrayDataPreparer {
 
         if chi_squared_statistic.is_finite() {
             if expected_homozygous_allele2 > MIN_EXPECTED_FOR_DIVISION {
-                chi_squared_statistic +=
-                    (observed_homozygous_allele2_count as f64 - expected_homozygous_allele2).powi(2)
-                        / expected_homozygous_allele2;
+                chi_squared_statistic += (observed_homozygous_allele2_count as f64
+                    - expected_homozygous_allele2)
+                    .powi(2)
+                    / expected_homozygous_allele2;
             } else if (observed_homozygous_allele2_count as f64) > MIN_EXPECTED_FOR_DIVISION {
                 chi_squared_statistic = f64::INFINITY;
             }
@@ -1885,11 +1979,17 @@ impl PcaReadyGenotypeAccessor for MicroarrayGenotypeAccessor {
             let (response_tx, response_rx) = flume::bounded(1);
             let request = io_service_infrastructure::IoRequest::GetSnpBlockForEigen {
                 original_m_indices_for_bed,
-                original_sample_indices_for_bed: Arc::new(requested_original_sample_indices_for_bed),
+                original_sample_indices_for_bed: Arc::new(
+                    requested_original_sample_indices_for_bed,
+                ),
                 response_tx,
             };
 
-            self.io_request_tx.send_timeout(request, io_service_infrastructure::DEFAULT_IO_OPERATION_TIMEOUT)
+            self.io_request_tx
+                .send_timeout(
+                    request,
+                    io_service_infrastructure::DEFAULT_IO_OPERATION_TIMEOUT,
+                )
                 .wrap_err_with_str("Failed to send SnpBlockForEigen request to IoService")?;
 
             match response_rx.recv_timeout(io_service_infrastructure::DEFAULT_IO_OPERATION_TIMEOUT)

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -3,21 +3,17 @@
 // --- External Crate Imports ---
 use anyhow::{anyhow, Result};
 use log::{debug, warn};
-use ndarray::{Array2};
-use noodles_vcf::{Record as VcfRecord, Header as VcfHeader};
-use std::{
-    path::Path,
-    sync::Arc,
-};
-
+use ndarray::Array2;
+use noodles_vcf::{Header as VcfHeader, Record as VcfRecord};
+use std::{path::Path, sync::Arc};
 
 pub mod vcf_processing {
-    use super::{anyhow, debug, warn, Result, Path, Arc, VcfHeader, VcfRecord};
-        
+    use super::{anyhow, debug, warn, Arc, Path, Result, VcfHeader, VcfRecord};
+
     use noodles_vcf::variant::record::samples::series::Value as GenotypeValue;
-     // Explicitly import for `samples::` paths if needed
-    use noodles_vcf::variant::record::AlternateBases as _; // Use _ to import trait methods
-    use noodles_vcf::variant::record::samples::Series as SeriesTrait; // For explicit trait method calls
+    // Explicitly import for `samples::` paths if needed
+    use noodles_vcf::variant::record::samples::Series as SeriesTrait;
+    use noodles_vcf::variant::record::AlternateBases as _; // Use _ to import trait methods // For explicit trait method calls
 
     #[derive(Debug)]
     pub struct SamplesHeaderInfo {
@@ -51,13 +47,23 @@ pub mod vcf_processing {
     #[inline(always)]
     fn parse_gt_to_option_u8(gt_string: &str) -> Option<u8> {
         let bytes = gt_string.as_bytes();
-        if bytes.len() != 3 { return None; }
-        if bytes[1] != b'/' && bytes[1] != b'|' { return None; }
+        if bytes.len() != 3 {
+            return None;
+        }
+        if bytes[1] != b'/' && bytes[1] != b'|' {
+            return None;
+        }
         let allele1 = match bytes[0] {
-            b'0' => 0u8, b'1' => 1u8, b'.' => return None, _ => return None,
+            b'0' => 0u8,
+            b'1' => 1u8,
+            b'.' => return None,
+            _ => return None,
         };
         let allele2 = match bytes[2] {
-            b'0' => 0u8, b'1' => 1u8, b'.' => return None, _ => return None,
+            b'0' => 0u8,
+            b'1' => 1u8,
+            b'.' => return None,
+            _ => return None,
         };
         Some(allele1 + allele2)
     }
@@ -87,13 +93,14 @@ pub mod vcf_processing {
                 first_vcf_path_for_error_msg.display()
             ));
         }
-        
+
         let gt_key_str = "GT"; // Changed to GenotypeKey
 
         if !current_header.formats().contains_key(gt_key_str) {
             return Err(anyhow!(
                 "GT key (FORMAT={}) not found in FORMAT header for VCF {}",
-                gt_key_str, vcf_path.display()
+                gt_key_str,
+                vcf_path.display()
             ));
         }
 
@@ -106,9 +113,8 @@ pub mod vcf_processing {
             let ref_bases_str = record.reference_bases();
             let alt_bases_obj = record.alternate_bases();
 
-            if ref_bases_str.len() != 1
-                || alt_bases_obj.len() != 1
-            // Removed: || alt_bases_obj.as_ref().len() != 1 
+            if ref_bases_str.len() != 1 || alt_bases_obj.len() != 1
+            // Removed: || alt_bases_obj.as_ref().len() != 1
             {
                 debug!(
                     "Variant at {}:{} (REF:{}, ALT:{}) is not a bi-allelic SNP (single base REF, single base ALT), skipping.",
@@ -122,13 +128,19 @@ pub mod vcf_processing {
 
             let mut temp_genotypes_for_variant: Vec<u8> =
                 Vec::with_capacity(canonical_samples_info.sample_count);
-            let mut current_variant_has_gt_issues = false; 
-            
+            let mut current_variant_has_gt_issues = false;
+
             let samples_obj = record.samples();
 
             match samples_obj.select(gt_key_str) {
                 Some(gt_series_struct) => {
-                    for (sample_idx, value_option_result) in <noodles_vcf::record::samples::Series as SeriesTrait>::iter(&gt_series_struct, &current_header).enumerate() {
+                    for (sample_idx, value_option_result) in
+                        <noodles_vcf::record::samples::Series as SeriesTrait>::iter(
+                            &gt_series_struct,
+                            &current_header,
+                        )
+                        .enumerate()
+                    {
                         if sample_idx >= canonical_samples_info.sample_count {
                             warn!("More GT values in series than expected samples for variant at {}:{}. VCF: {}. Truncating.",
                                 record.reference_sequence_name(),
@@ -138,7 +150,8 @@ pub mod vcf_processing {
                             break;
                         }
                         match value_option_result {
-                            Ok(Some(GenotypeValue::String(gt_string_cow_val))) => { // Changed to GenotypeValue
+                            Ok(Some(GenotypeValue::String(gt_string_cow_val))) => {
+                                // Changed to GenotypeValue
                                 let gt_str_slice = gt_string_cow_val.as_ref();
                                 if let Some(gt_val) = parse_gt_to_option_u8(gt_str_slice) {
                                     temp_genotypes_for_variant.push(gt_val);
@@ -150,43 +163,54 @@ pub mod vcf_processing {
                                     break;
                                 }
                             }
-                            Ok(Some(GenotypeValue::Genotype(boxed_gt))) => { // Changed to GenotypeValue
+                            Ok(Some(GenotypeValue::Genotype(boxed_gt))) => {
+                                // Changed to GenotypeValue
                                 let genotype_data = &*boxed_gt;
                                 let mut allele_dosage_sum: u8 = 0;
                                 let mut alleles_processed_count = 0;
                                 let mut current_sample_gt_failed = false;
 
                                 for allele_info_result in genotype_data.iter() {
-                                    if alleles_processed_count >= 2 { break; }
+                                    if alleles_processed_count >= 2 {
+                                        break;
+                                    }
                                     match allele_info_result {
-                                        Ok((Some(allele_idx), _)) => { // Phasing info ignored with _
-                                            if allele_idx == 0 { /* Ref allele */ }
-                                            else if allele_idx == 1 { allele_dosage_sum += 1; /* Alt allele */ }
-                                            else { 
+                                        Ok((Some(allele_idx), _)) => {
+                                            // Phasing info ignored with _
+                                            if allele_idx == 0 { /* Ref allele */
+                                            } else if allele_idx == 1 {
+                                                allele_dosage_sum += 1; /* Alt allele */
+                                            } else {
                                                 debug!("Variant at {}:{}: Sample #{} GT has unexpected allele index {} (>1) for bi-allelic site. Invalidating.",
                                                     record.reference_sequence_name(), record.variant_start().map_or(0u64, |r_p| r_p.map_or(0u64, |p|p.get() as u64)),
                                                     sample_idx, allele_idx);
-                                                current_sample_gt_failed = true; break;
+                                                current_sample_gt_failed = true;
+                                                break;
                                             }
                                         }
-                                        Ok((None, _)) => { /* Missing allele '.' */ // Phasing info ignored
+                                        Ok((None, _)) => {
+                                            /* Missing allele '.' */
+ // Phasing info ignored
                                             debug!("Variant at {}:{}: Sample #{} GT contains missing allele ('.'). Invalidating.",
                                                 record.reference_sequence_name(), record.variant_start().map_or(0u64, |r_p| r_p.map_or(0u64, |p|p.get() as u64)),
                                                 sample_idx);
-                                            current_sample_gt_failed = true; break;
+                                            current_sample_gt_failed = true;
+                                            break;
                                         }
                                         Err(e) => {
                                             warn!("Variant at {}:{}: Error iterating GT alleles for sample #{}: {}. Invalidating.",
                                                 record.reference_sequence_name(), record.variant_start().map_or(0u64, |r_p| r_p.map_or(0u64, |p|p.get() as u64)),
                                                 sample_idx, e);
-                                            current_sample_gt_failed = true; break;
+                                            current_sample_gt_failed = true;
+                                            break;
                                         }
                                     }
                                     alleles_processed_count += 1;
                                 }
 
                                 if current_sample_gt_failed || alleles_processed_count != 2 {
-                                    current_variant_has_gt_issues = true; break;
+                                    current_variant_has_gt_issues = true;
+                                    break;
                                 } else {
                                     temp_genotypes_for_variant.push(allele_dosage_sum);
                                 }
@@ -198,14 +222,14 @@ pub mod vcf_processing {
                                 current_variant_has_gt_issues = true;
                                 break;
                             }
-                            Ok(None) => { 
+                            Ok(None) => {
                                 debug!("Variant at {}:{}: GT field for sample {} is missing (None value). Skipping variant.",
                                     record.reference_sequence_name(), record.variant_start().map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64)),
                                     sample_idx);
                                 current_variant_has_gt_issues = true;
                                 break;
                             }
-                            Err(e) => { 
+                            Err(e) => {
                                 warn!("Error parsing a genotype value for variant at {}:{} in VCF {}: {}. Skipping variant.",
                                     record.reference_sequence_name(), record.variant_start().map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64)),
                                     vcf_path.display(), e);
@@ -215,11 +239,15 @@ pub mod vcf_processing {
                         }
                     }
                 }
-                None => { 
-                    debug!("Variant at {}:{}: GT series not found in VCF {}. Skipping variant.",
+                None => {
+                    debug!(
+                        "Variant at {}:{}: GT series not found in VCF {}. Skipping variant.",
                         record.reference_sequence_name(),
-                        record.variant_start().map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64)),
-                        vcf_path.display());
+                        record
+                            .variant_start()
+                            .map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64)),
+                        vcf_path.display()
+                    );
                     current_variant_has_gt_issues = true;
                 }
             }
@@ -244,7 +272,7 @@ pub mod vcf_processing {
             let allele_sum: u32 = temp_genotypes_for_variant.iter().map(|&g| g as u32).sum();
             let num_alleles_total: u32 = (canonical_samples_info.sample_count * 2) as u32;
 
-            if num_alleles_total == 0 { 
+            if num_alleles_total == 0 {
                 debug!("Variant at {}:{}: No alleles to calculate MAF (num_alleles_total is 0). Skipping.",
                     record.reference_sequence_name(),
                     record.variant_start().map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64)));
@@ -257,20 +285,29 @@ pub mod vcf_processing {
             let actual_maf_threshold = cli_args.maf.unwrap_or(0.01); // Default to 0.01 if None
 
             if maf < actual_maf_threshold {
-                debug!("Variant at {}:{}:{} (MAF={:.4}) below threshold ({:.4}). Skipping.",
+                debug!(
+                    "Variant at {}:{}:{} (MAF={:.4}) below threshold ({:.4}). Skipping.",
                     record.reference_sequence_name(),
-                    record.variant_start().map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64)),
+                    record
+                        .variant_start()
+                        .map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64)),
                     record.reference_bases(),
-                    maf, actual_maf_threshold); // Use actual_maf_threshold for comparison and Display
+                    maf,
+                    actual_maf_threshold
+                ); // Use actual_maf_threshold for comparison and Display
                 continue;
             }
-            
+
             let alt_allele_str = alt_bases_obj.as_ref().to_string();
             let chrom_str = record.reference_sequence_name().to_string();
-            let pos_val = record.variant_start().map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64));
-            
-            let variant_id =
-                format!("{}:{}:{}:{}", chrom_str, pos_val, ref_bases_str, alt_allele_str);
+            let pos_val = record
+                .variant_start()
+                .map_or(0u64, |res_p| res_p.map_or(0u64, |p| p.get() as u64));
+
+            let variant_id = format!(
+                "{}:{}:{}:{}",
+                chrom_str, pos_val, ref_bases_str, alt_allele_str
+            );
 
             chromosome_variants_data.push(VariantGenotypeData {
                 id: variant_id,
@@ -287,12 +324,13 @@ pub mod vcf_processing {
 }
 
 pub mod matrix_ops {
-    use super::{anyhow, Result, Array2};
     use super::vcf_processing::VariantGenotypeData;
+    use super::{anyhow, Array2, Result};
 
     pub fn aggregate_chromosome_data(
         per_chromosome_data: Vec<Vec<VariantGenotypeData>>,
-    ) -> (Vec<String>, Vec<Vec<u8>>) { // Changed return type
+    ) -> (Vec<String>, Vec<Vec<u8>>) {
+        // Changed return type
         let mut all_variant_ids = Vec::new();
         // Removed: let mut all_chromosomes = Vec::new();
         // Removed: let mut all_positions = Vec::new();
@@ -327,13 +365,13 @@ pub mod matrix_ops {
         }
 
         let mut final_matrix = Array2::<f64>::zeros((num_samples, num_variants));
-        for (variant_idx, genotypes_for_one_variant) in
-            variant_genotypes_major.iter().enumerate()
-        {
+        for (variant_idx, genotypes_for_one_variant) in variant_genotypes_major.iter().enumerate() {
             if genotypes_for_one_variant.len() != num_samples {
                 return Err(anyhow!(
                     "Genotype count mismatch for variant index {}: expected {}, found {}.",
-                    variant_idx, num_samples, genotypes_for_one_variant.len()
+                    variant_idx,
+                    num_samples,
+                    genotypes_for_one_variant.len()
                 ));
             }
             for sample_idx in 0..num_samples {


### PR DESCRIPTION
This commit introduces the `--save-local-pcs <DIR>` command-line argument. When specified along with `--eigensnp`, this flag instructs the program to save the intermediate local principal components (eigenSNP loadings) for each LD block as separate .tsv files within the given directory.

This leverages an existing, but previously unused, capability in the `eigensnp` library, providing a zero-cost abstraction when the feature is not active due to compile-time monomorphization.